### PR TITLE
Updated YAML format to support different enumerated values for R/W

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can see current coverage status for each chip
 [here](https://stm32.agg.io/rs). That page also allows you to drill down
 into each field on each register on each peripheral.
 
-## Using Device Crates In Your Own Pooject
+## Using Device Crates In Your Own Project
 
 At the moment none of these crates are published on crates.io, so you must
 clone this repository and generate them yourself (see below) before you can
@@ -212,11 +212,18 @@ _add:
             # By giving the field a dictionary we construct an enumerateValues
             VARIANT: [VALUE, DESCRIPTION]
             VARIANT: [VALUE, DESCRIPTION]
-            # Optional usage key specifies read, write, or read-write (default)
-            _usage: read
 
         # Another field. A list of two numbers gives a range writeConstraint.
         FIELD: [MINIMUM, MAXIMUM]
+
+        # Another field with separate enumuerated values for read and write
+        FIELD:
+            _read:
+                VARIANT: [VALUE, DESCRIPTION]
+                VARIANT: [VALUE, DESCRIPTION]
+            _write:
+                VARIANT: [VALUE, DESCRIPTION]
+                VARIANT: [VALUE, DESCRIPTION]
 ```
 
 ### Name Matching

--- a/peripherals/adc/adc_v2.yaml
+++ b/peripherals/adc/adc_v2.yaml
@@ -63,8 +63,8 @@
     AWDCH: [0, 18]
   CR2:
     SWSTART:
-      Start: [1, "Starts conversion of regular channels"]
-      _usage: write
+      _write:
+        Start: [1, "Starts conversion of regular channels"]
     EXTEN:
       Disabled: [0, "Trigger detection disabled"]
       RisingEdge: [1, "Trigger detection on the rising edge"]
@@ -79,8 +79,8 @@
       TIM2CC4: [5, "Timer 2 CC4 event"]
       TIM2TRGO: [6, "Timer 2 TRGO event"]
     JSWSTART:
-      Start: [1, "Starts conversion of injected channels"]
-      _usage: write
+      _write:
+        Start: [1, "Starts conversion of injected channels"]
     JEXTEN:
       Disabled: [0, "Trigger detection disabled"]
       RisingEdge: [1, "Trigger detection on the rising edge"]

--- a/peripherals/crc/crc_basic.yaml
+++ b/peripherals/crc/crc_basic.yaml
@@ -9,5 +9,5 @@ CRC:
     IDR: [0, 255]
   CR:
     RESET:
-      Reset: [1, "Resets the CRC calculation unit and sets the data register to 0xFFFF FFFF"]
-      _usage: write
+      _write:
+        Reset: [1, "Resets the CRC calculation unit and sets the data register to 0xFFFF FFFF"]

--- a/peripherals/gpio/gpio_v2.yaml
+++ b/peripherals/gpio/gpio_v2.yaml
@@ -24,11 +24,11 @@
       PullDown: [2, "Pull-down"]
   BSRR:
     "BR*":
-      Reset: [1, "Resets the corresponding ODRx bit"]
-      _usage: write
+      _write:
+        Reset: [1, "Resets the corresponding ODRx bit"]
     "BS*":
-      Set: [1, "Sets the corresponding ODRx bit"]
-      _usage: write
+      _write:
+        Set: [1, "Sets the corresponding ODRx bit"]
   LCKR:
     "LCK[0123456789][012345]":
       Unlocked: [0, "Port configuration not locked"]

--- a/peripherals/rcc/rcc_v2.yaml
+++ b/peripherals/rcc/rcc_v2.yaml
@@ -53,10 +53,10 @@ RCC:
       DIV256: [14, "system clock divided by 256"]
       DIV512: [15, "system clock divided by 512"]
     SWS:
-      HSI: [0, "HSI oscillator used as the system clock"]
-      HSE: [1, "HSE oscillator used as the system clock"]
-      PLL: [2, "PLL used as the system clock"]
-      _usage: read
+      _read:
+        HSI: [0, "HSI oscillator used as the system clock"]
+        HSE: [1, "HSE oscillator used as the system clock"]
+        PLL: [2, "PLL used as the system clock"]
     SW:
       HSI: [0, "HSI oscillator selected as system clock"]
       HSE: [1, "HSE oscillator selected as system clock"]
@@ -88,9 +88,9 @@ RCC:
       NotBypassed: [0, "LSE oscillator not bypassed"]
       Bypassed: [1, "LSE oscillator bypassed"]
     LSERDY:
-      NotReady: [0, "LSE clock not ready"]
-      Ready: [1, "LSE clock ready"]
-      _usage: read
+      _read:
+        NotReady: [0, "LSE clock not ready"]
+        Ready: [1, "LSE clock ready"]
     LSEON:
       Disabled: [0, "LSE clock OFF"]
       Enabled: [1, "LSE clock ON"]

--- a/peripherals/spi/spi_common.yaml
+++ b/peripherals/spi/spi_common.yaml
@@ -70,28 +70,28 @@
       Enabled: [1, "Rx buffer DMA enabled"]
   SR:
     FRE:
-      NoError: [0, "No frame format error"]
-      Error: [1, "A frame format error occurred"]
-      _usage: read
+      _read:
+        NoError: [0, "No frame format error"]
+        Error: [1, "A frame format error occurred"]
     BSY:
-      NotBusy: [0, "SPI not busy"]
-      Busy: [1, "SPI busy"]
-      _usage: read
+      _read:
+        NotBusy: [0, "SPI not busy"]
+        Busy: [1, "SPI busy"]
     OVR:
-      NoOverrun: [0, "No overrun occurred"]
-      Overrun: [1, "Overrun occurred"]
-      _usage: read
+      _read:
+        NoOverrun: [0, "No overrun occurred"]
+        Overrun: [1, "Overrun occurred"]
     MODF:
-      NoFault: [0, "No mode fault occurred"]
-      Fault: [1, "Mode fault occurred"]
-      _usage: read
+      _read:
+        NoFault: [0, "No mode fault occurred"]
+        Fault: [1, "Mode fault occurred"]
     CRCERR:
       Match: [0, "CRC value received matches the SPIx_RXCRCR value"]
       NoMatch: [1, "CRC value received does not match the SPIx_RXCRCR value"]
     UDR:
-      NoUnderrun: [0, "No underrun occurred"]
-      Underrun: [1, "Underrun occurred"]
-      _usage: read
+      _read:
+        NoUnderrun: [0, "No underrun occurred"]
+        Underrun: [1, "Underrun occurred"]
     CHSIDE:
       Left: [0, "Channel left has to be transmitted or has been received"]
       Right: [1, "Channel right has to be transmitted or has been received"]

--- a/peripherals/spi/spi_v2.yaml
+++ b/peripherals/spi/spi_v2.yaml
@@ -37,14 +37,14 @@ _include:
       PulseGenerated: [1, "NSS pulse generated"]
   SR:
     FTLVL:
-      Empty: [0, "Tx FIFO Empty"]
-      Quarter: [1, "Tx 1/4 FIFO"]
-      Half: [2, "Tx 1/2 FIFO"]
-      Full: [3, "Tx FIFO full"]
-      _usage: read
+      _read:
+        Empty: [0, "Tx FIFO Empty"]
+        Quarter: [1, "Tx 1/4 FIFO"]
+        Half: [2, "Tx 1/2 FIFO"]
+        Full: [3, "Tx FIFO full"]
     FRLVL:
-      Empty: [0, "Rx FIFO Empty"]
-      Quarter: [1, "Rx 1/4 FIFO"]
-      Half: [2, "Rx 1/2 FIFO"]
-      Full: [3, "Rx FIFO full"]
-      _usage: read
+      _read:
+        Empty: [0, "Rx FIFO Empty"]
+        Quarter: [1, "Rx 1/4 FIFO"]
+        Half: [2, "Rx 1/2 FIFO"]
+        Full: [3, "Rx FIFO full"]


### PR DESCRIPTION
The previous YAML format didn't support separate enumerated values for read and write usage.  This is required e.g. here http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/Cihcajhj.html

I updated the peripheral yaml files that used the old format and the README example.  There was also quite a funny typo in the README :hankey: :scream: :see_no_evil: 