### PR TITLE
fix matching of LCKR fields in GPIO_v2

### DIFF
--- a/peripherals/gpio/gpio_v2.yaml
+++ b/peripherals/gpio/gpio_v2.yaml
@@ -30,7 +30,10 @@
       _write:
         Set: [1, "Sets the corresponding ODRx bit"]
   LCKR:
-    "LCK[0123456789][012345]":
+    "LCK[0123456789]":
+      Unlocked: [0, "Port configuration not locked"]
+      Locked: [1, "Port configuration locked"]
+    "LCK1[012345]":
       Unlocked: [0, "Port configuration not locked"]
       Locked: [1, "Port configuration locked"]
   "AFR[LH]":


### PR DESCRIPTION
`fnname` doesn't seem to support `([0-9]|1[0-5])` regex, so I couldn't think of any more elegant solution than copying the descriptions.