### PR TITLE
Missing patch for `stm32f446`

### DIFF
--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -49,3 +49,4 @@ _include:
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/rcc/rcc_v2.yaml


### PR DESCRIPTION
Hi,
It seems that there is a missing patch for the microcontroller `stm32f446`.
Please tell me if there is any problem with this change ! :smile: