### PR TITLE
Add missing stm32h7 ethernet

### DIFF
--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -4,6 +4,1762 @@ _svd: ../svd/stm32h7x3.svd
 _modify:
   Flash:
     name: FLASH
+  Ethernet_MAC:
+    name: Ethernet_DMA
+    baseAddress: 0x40029000
+    description: "Ethernet: DMA controller operation"
+
+_add:
+  Ethernet_MAC:
+    baseAddress: 0x40028000
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+    registers:
+      MACCR:
+        description: Ethernet MAC Operating mode configuration register
+        addressOffset: 0x0
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          RE:
+            description: Receiver Enable
+            bitOffset: 0
+            bitWidth: 1
+          TE:
+            description: Transmitter Enable
+            bitOffset: 1
+            bitWidth: 1
+          PRELEN:
+            description: Preamble Length for Transmit Packets
+            bitOffset: 2
+            bitWidth: 2
+          DC:
+            description: Deferral Check
+            bitOffset: 4
+            bitWidth: 1
+          BL:
+            description: Back-Off Limit
+            bitOffset: 5
+            bitWidth: 2
+          DR:
+            description: Disable Retry
+            bitOffset: 8
+            bitWidth: 1
+          DCRS:
+            description: Disable Carrier Sense During Transmission
+            bitOffset: 9
+            bitWidth: 1
+          DO:
+            description: Disable Receive Own
+            bitOffset: 10
+            bitWidth: 1
+          ECRSFD:
+            description: Enable Carrier Sense Before Transmission in Full-Duplex Mode
+            bitOffset: 11
+            bitWidth: 1
+          LM:
+            description: Loopback Mode
+            bitOffset: 12
+            bitWidth: 1
+          DM:
+            description: Duplex Mode
+            bitOffset: 13
+            bitWidth: 1
+          FES:
+            description: MAC Speed
+            bitOffset: 14
+            bitWidth: 1
+          JE:
+            description: Jumbo Packet Enable
+            bitOffset: 16
+            bitWidth: 1
+          JD:
+            description: Jabber Disable
+            bitOffset: 17
+            bitWidth: 1
+          WD:
+            description: Watchdog Disable
+            bitOffset: 19
+            bitWidth: 1
+          ACS:
+            description: Automatic Pad or CRC Stripping
+            bitOffset: 20
+            bitWidth: 1
+          CST:
+            description: CRC stripping for Type packets
+            bitOffset: 21
+            bitWidth: 1
+          S2KP:
+            description: IEEE 802.3as Support for 2K Packets
+            bitOffset: 22
+            bitWidth: 1
+          GPSLCE:
+            description: Giant Packet Size Limit Control Enable
+            bitOffset: 23
+            bitWidth: 1
+          IPG:
+            description: Inter-Packet Gap
+            bitOffset: 24
+            bitWidth: 3
+          IPC:
+            description: Checksum Offload
+            bitOffset: 27
+            bitWidth: 1
+          SARC:
+            description: Source Address Insertion or Replacement Control
+            bitOffset: 28
+            bitWidth: 3
+          ARPEN:
+            description: ARP Offload Enable
+            bitOffset: 31
+            bitWidth: 1
+      MACECR:
+        description: Ethernet MAC Extended operating mode configuration register
+        addressOffset: 0x4
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          GPSL:
+            description: Giant Packet Size Limit
+            bitOffset: 0
+            bitWidth: 14
+          DCRCC:
+            description: Disable CRC Checking for Received Packets
+            bitOffset: 16
+            bitWidth: 1
+          SPEN:
+            description: Slow Protocol Detection Enable
+            bitOffset: 17
+            bitWidth: 1
+          USP:
+            description: Unicast Slow Protocol Packet Detect
+            bitOffset: 18
+            bitWidth: 1
+          EIPGEN:
+            description: Extended Inter-Packet Gap Enable
+            bitOffset: 24
+            bitWidth: 1
+          EIPG:
+            description: Extended Inter-Packet Gap
+            bitOffset: 25
+            bitWidth: 5
+      MACPFR:
+        description: Ethernet MAC Packet filtering control register
+        addressOffset: 0x8
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          RA:
+            description: Receive All
+            bitOffset: 31 
+            bitWidth: 1
+          DNTU:
+            description: Drop Non-TCP/UDP over IP Packets
+            bitOffset: 21 
+            bitWidth: 1
+          IPFE:
+            description: Layer 3 and Layer 4 Filter Enable
+            bitOffset: 20 
+            bitWidth: 1
+          VTFE:
+            description: VLAN Tag Filter Enable
+            bitOffset: 16 
+            bitWidth: 1
+          HPF:
+            description: Hash or Perfect Filter
+            bitOffset: 10 
+            bitWidth: 1
+          SAF:
+            description: Source Address Filter Enable
+            bitOffset: 9 
+            bitWidth: 1
+          SAIF:
+            description: SA Inverse Filtering
+            bitOffset: 8 
+            bitWidth: 1
+          PCF:
+            description: Pass Control Packets
+            bitOffset: 6
+            bitWidth: 2
+          DBF:
+            description: Disable Broadcast Packets
+            bitOffset: 5 
+            bitWidth: 1
+          PM:
+            description: Pass All Multicast
+            bitOffset: 4 
+            bitWidth: 1
+          DAIF:
+            description: DA Inverse Filtering
+            bitOffset: 3 
+            bitWidth: 1
+          HMC:
+            description: Hash Multicast
+            bitOffset: 2
+            bitWidth: 1
+          HUC:
+            description: Hash Unicast
+            bitOffset: 1
+            bitWidth: 1
+          PR:
+            description: Promiscuous Mode
+            bitOffset: 0
+            bitWidth: 1
+      MACWTR:
+        description: Ethernet MAC Watchdog timeout register
+        addressOffset: 0xC
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          WTO:
+            description: Watchdog Timeout
+            bitOffset: 0
+            bitWidth: 4
+          PWE:
+            description: Programmable Watchdog Enable
+            bitOffset: 8
+            bitWidth: 1
+      MACHT0R:
+        description: Ethernet MAC Hash Table 0 register
+        addressOffset: 0x10
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          HT31T0:
+            description: MAC Hash Table First 32 Bits
+            bitOffset: 0
+            bitWidth: 32
+      MACHT1R:
+        description: Ethernet MAC Hash Table 1 register
+        addressOffset: 0x14
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          HT63T32:
+            description: MAC Hash Table Second 32 Bits
+            bitOffset: 0
+            bitWidth: 32
+      MACVTR:
+        description: Ethernet MAC VLAN tag register
+        addressOffset: 0x50
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          EIVLRXS:
+            description: Enable Inner VLAN Tag in Rx Status
+            bitOffset: 31 
+            bitWidth: 1
+          EIVLS:
+            description: Enable Inner VLAN Tag Stripping on Receive
+            bitOffset: 28
+            bitWidth: 2
+          ERIVLT:
+            description: Enable Inner VLAN Tag
+            bitOffset: 27 
+            bitWidth: 1
+          EDVLP:
+            description: Enable Double VLAN Processing
+            bitOffset: 26 
+            bitWidth: 1
+          VTHM:
+            description: VLAN Tag Hash Table Match Enable
+            bitOffset: 25 
+            bitWidth: 1
+          EVLRXS:
+            description: Enable VLAN Tag in Rx status
+            bitOffset: 24 
+            bitWidth: 1
+          EVLS:
+            description: Enable VLAN Tag Stripping on Receive
+            bitOffset: 21
+            bitWidth: 2
+          DOVLTC:
+            description: Disable VLAN Type Check
+            bitOffset: 20 
+            bitWidth: 1
+          ERSVLM:
+            description: Enable Receive S-VLAN Match
+            bitOffset: 19 
+            bitWidth: 1
+          ESVL:
+            description: Enable S-VLAN
+            bitOffset: 18 
+            bitWidth: 1
+          VTIM:
+            description: VLAN Tag Inverse Match Enable
+            bitOffset: 17 
+            bitWidth: 1
+          ETV:
+            description: Enable 12-Bit VLAN Tag Comparison
+            bitOffset: 16 
+            bitWidth: 1
+          VL:
+            description: VLAN Tag Identifier for Receive Packets
+            bitOffset: 0
+            bitWidth: 16
+      MACVHTR:
+        description: Ethernet MAC VLAN Hash table register
+        addressOffset: 0x58
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          VLHT:
+            description: VLAN Hash Table
+            bitOffset: 0
+            bitWidth: 16
+      MACVIR:
+        description: Ethernet MAC VLAN inclusion register
+        addressOffset: 0x60
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          VLTI:
+            description: VLAN Tag Input
+            bitOffset: 20 
+            bitWidth: 1
+          CSVL:
+            description: C-VLAN or S-VLAN
+            bitOffset: 19 
+            bitWidth: 1
+          VLP:
+            description: VLAN Priority Control
+            bitOffset: 18 
+            bitWidth: 1
+          VLC:
+            description: VLAN Tag Control in Transmit Packets
+            bitOffset: 16 
+            bitWidth: 2
+          VLT:
+            description: VLAN Tag for Transmit Packets
+            bitOffset: 0 
+            bitWidth: 16
+      MACIVIR:
+        description: Ethernet MAC Inner VLAN inclusion register
+        addressOffset: 0x64
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          VLTI:
+            description: VLAN Tag Input
+            bitOffset: 20 
+            bitWidth: 1
+          CSVL:
+            description: C-VLAN or S-VLAN
+            bitOffset: 19 
+            bitWidth: 1
+          VLP:
+            description: VLAN Priority Control
+            bitOffset: 18 
+            bitWidth: 1
+          VLC:
+            description: VLAN Tag Control in Transmit Packets
+            bitOffset: 16 
+            bitWidth: 2
+          VLT:
+            description: VLAN Tag for Transmit Packets
+            bitOffset: 0 
+            bitWidth: 16
+      MACQTXFCR:
+        description: Ethernet MAC Tx Queue flow control register
+        addressOffset: 0x70
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          PT:
+            description: Pause Time
+            bitOffset: 16 
+            bitWidth: 16
+          DZPQ:
+            description: Disable Zero-Quanta Pause
+            bitOffset: 7 
+            bitWidth: 1
+          PLT:
+            description: Pause Low Threshold
+            bitOffset: 4 
+            bitWidth: 3
+          TFE:
+            description: Transmit Flow Control Enable
+            bitOffset: 1 
+            bitWidth: 1
+          FCB_BPA:
+            description: Flow Control Busy or Backpressure Activate
+            bitOffset: 0 
+            bitWidth: 1
+      MACRXFCR:
+        description: Ethernet MAC Rx flow control register
+        addressOffset: 0x90
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          UP:
+            description: Unicast Pause Packet Detect
+            bitOffset: 1 
+            bitWidth: 1
+          RFE:
+            description: Receive Flow Control Enable
+            bitOffset: 0 
+            bitWidth: 1
+      MACISR:
+        description: Ethernet MAC Interupt status register
+        addressOffset: 0xB0
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          RXSTSIS:
+            description: Receive Status Interrupt
+            bitOffset: 14 
+            bitWidth: 1
+          TXSTSIS:
+            description: Transmit Status Interrupt
+            bitOffset: 13 
+            bitWidth: 1
+          TSIS:
+            description: Timestamp Interrupt Status
+            bitOffset: 12 
+            bitWidth: 1
+          MMCTXIS:
+            description: MMC Transmit Interrupt Status
+            bitOffset: 10 
+            bitWidth: 1
+          MMCRXIS:
+            description: MMC Receive Interrupt Status
+            bitOffset: 9 
+            bitWidth: 1
+          MMCIS:
+            description: MMC Interrupt Status
+            bitOffset: 8 
+            bitWidth: 1
+          LPIIS:
+            description: LPI Interrupt Status
+            bitOffset: 5 
+            bitWidth: 1
+          PMTIS:
+            description: PMT Interrupt Status
+            bitOffset: 4 
+            bitWidth: 1
+          PHYIS:
+            description: PHY Interrupt
+            bitOffset: 3 
+            bitWidth: 1
+      MACIER:
+        description: Ethernet MAC Interupt enable register
+        addressOffset: 0xB4
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          RXSTSIE:
+            description: Receive Status Interrupt Enable
+            bitOffset: 14 
+            bitWidth: 1
+          TXSTSIE:
+            description: Transmit Status Interrupt Enable
+            bitOffset: 13 
+            bitWidth: 1
+          TSIE:
+            description: Timestamp Interrupt Enable
+            bitOffset: 12 
+            bitWidth: 1
+          LPIIE:
+            description: LPI Interrupt Enable
+            bitOffset: 5 
+            bitWidth: 1
+          PMTIE:
+            description: PMT Interrupt Enable
+            bitOffset: 4 
+            bitWidth: 1
+          PHYIE:
+            description: PHY Interrupt Enable
+            bitOffset: 3 
+            bitWidth: 1
+      MACRXTXSR:
+        description: Ethernet MAC Rx Tx status register
+        addressOffset: 0xB8
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          RWT:
+            description: Receive Watchdog Timeout
+            bitOffset: 8 
+            bitWidth: 1
+          EXCOL:
+            description: Excessive Collisions
+            bitOffset: 5 
+            bitWidth: 1
+          LCOL:
+            description: Late Collision
+            bitOffset: 4 
+            bitWidth: 1
+          EXDEF:
+            description: Excessive Deferral
+            bitOffset: 3 
+            bitWidth: 1
+          LCARR:
+            description: Loss of Carrier
+            bitOffset: 2 
+            bitWidth: 1
+          NCARR:
+            description: No Carrier
+            bitOffset: 1 
+            bitWidth: 1
+          TJT:
+            description: Transmit Jabber Timeout
+            bitOffset: 0 
+            bitWidth: 1
+      MACPCSR:
+        description: Ethernet MAC PMT control status register
+        addressOffset: 0xC0
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          RWKFILTRST:
+            description: Remote wakeup Packet Filter Register Pointer Reset
+            bitOffset: 31 
+            bitWidth: 1
+          RWKPTR:
+            description: Remote wakeup FIFO Pointer
+            bitOffset: 24 
+            bitWidth: 5
+          RWKPFE:
+            description: Remote wakeup Packet Forwarding Enable
+            bitOffset: 10 
+            bitWidth: 1
+          GLBLUCAST:
+            description: Global Unicast
+            bitOffset: 9 
+            bitWidth: 1
+          RWKPRCVD:
+            description: Remote wakeup Packet Received
+            bitOffset: 6 
+            bitWidth: 1
+          MGKPRCVD:
+            description: Magic Packet Received
+            bitOffset: 5 
+            bitWidth: 1
+          RWKPKTEN:
+            description: Remote wakeup Packet Enable
+            bitOffset: 2 
+            bitWidth: 1
+          MGKPKTEN:
+            description: Magic Packet Enable
+            bitOffset: 1 
+            bitWidth: 1
+          PWRDWN:
+            description: Power Down
+            bitOffset: 0 
+            bitWidth: 1
+      MACRWKPFR:
+        description: Ethernet MAC Remote wakeup packet filter register
+        addressOffset: 0xC4
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          MACRWKPFR:
+            description: Remote wakeup packet filter
+            bitOffset: 0
+            bitWidth: 32
+      MACLCSR:
+        description: Ethernet MAC LPI control status register
+        addressOffset: 0xD0
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          LPITE:
+            description: LPI Timer Enable
+            bitOffset: 20 
+            bitWidth: 1
+          LPITXA:
+            description: LPI Tx Automate
+            bitOffset: 19 
+            bitWidth: 1
+          PLSEN:
+            description: PHY Link Status Enable
+            bitOffset: 18 
+            bitWidth: 1
+          PLS:
+            description: PHY Link Status
+            bitOffset: 17 
+            bitWidth: 1
+          LPIEN:
+            description: LPI Enable
+            bitOffset: 16 
+            bitWidth: 1
+          RLPIST:
+            description: Receive LPI State
+            bitOffset: 9 
+            bitWidth: 1
+          TLPIST:
+            description: Transmit LPI State
+            bitOffset: 8 
+            bitWidth: 1
+          RLPIEX:
+            description: Receive LPI Exit
+            bitOffset: 3 
+            bitWidth: 1
+          RLPIEN:
+            description: Receive LPI Entry
+            bitOffset: 2 
+            bitWidth: 1
+          TLPIEX:
+            description: Transmit LPI Exit
+            bitOffset: 1 
+            bitWidth: 1
+          TLPIEN:
+            description: Transmit LPI Entry
+            bitOffset: 0 
+            bitWidth: 1
+      MACLTCR:
+        description: Ethernet MAC LPI timers control register
+        addressOffset: 0xD4
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          LST:
+            description: LPI LS Timer
+            bitOffset: 16 
+            bitWidth: 10
+          TWT:
+            description: LPI TW Timer
+            bitOffset: 0 
+            bitWidth: 16
+      MACLETR:
+        description: LPI entry timer register
+        addressOffset: 0x00D8
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          LPIET:
+            description: LPI Entry Timer
+            bitOffset: 3
+            bitWidth: 17
+      MAC1USTCR:
+        description: 1-microsecond-tick counter register
+        addressOffset: 0x00DC
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          TIC_1US_CNTR:
+            description: 1 µs tick Counter
+            bitOffset: 0
+            bitWidth: 12
+      MACVR:
+        description: Version register
+        addressOffset: 0x0110
+        resetValue: 0x00003041
+        access: read-write
+        fields:
+          USERVER:
+            description: ST-defined version
+            bitOffset: 8 
+            bitWidth: 8
+          SNPSVER:
+            description: IP version
+            bitOffset: 0 
+            bitWidth: 8
+      MACDR:
+        description: Debug register
+        addressOffset: 0x0114
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          TFCSTS:
+            description: MAC Transmit Packet Controller Status
+            bitOffset: 17 
+            bitWidth: 2
+          TPESTS:
+            description: MAC MII Transmit Protocol Engine Status
+            bitOffset: 16 
+            bitWidth: 1
+          RFCFCSTS:
+            description: MAC Receive Packet Controller FIFO Status
+            bitOffset: 1 
+            bitWidth: 2
+          RPESTS:
+            description: MAC MII Receive Protocol Engine Status
+            bitOffset: 0 
+            bitWidth: 1
+      MACHWF1R:
+        description: HW feature 1 register
+        addressOffset: 0x0120
+        resetValue: 0x11841904
+        access: read-write
+        fields:
+          L3L4FNUM:
+            description: Total number of L3 or L4 Filters
+            bitOffset: 27 
+            bitWidth: 4
+          HASHTBLSZ:
+            description: Hash Table Size
+            bitOffset: 24 
+            bitWidth: 2
+          AVSEL:
+            description: AV Feature Enable
+            bitOffset: 20 
+            bitWidth: 1
+          DBGMEMA:
+            description: DMA Debug Registers Enable
+            bitOffset: 19 
+            bitWidth: 1
+          TSOEN:
+            description: TCP Segmentation Offload Enable
+            bitOffset: 18 
+            bitWidth: 1
+          SPHEN:
+            description: Split Header Feature Enable
+            bitOffset: 17 
+            bitWidth: 1
+          DCBEN:
+            description: DCB Feature Enable
+            bitOffset: 16 
+            bitWidth: 1
+          ADDR64:
+            description: Address width
+            bitOffset: 14 
+            bitWidth: 2
+          ADVTHWORD:
+            description: IEEE 1588 High Word Register Enable
+            bitOffset: 13 
+            bitWidth: 1
+          PTOEN:
+            description: PTP Offload Enable
+            bitOffset: 12 
+            bitWidth: 1
+          OSTEN:
+            description: One-Step Timestamping Enable
+            bitOffset: 11 
+            bitWidth: 1
+          TXFIFOSIZE:
+            description: MTL Transmit FIFO Size
+            bitOffset: 6 
+            bitWidth: 5
+          RXFIFOSIZE:
+            description: MTL Receive FIFO Size
+            bitOffset: 0 
+            bitWidth: 5
+      MACHWF2R:
+        description: HW feature 2 register
+        addressOffset: 0x0124
+        resetValue: 0x41000000
+        access: read-write
+        fields:
+          AUXSNAPNUM:
+            description: Number of Auxiliary Snapshot Inputs
+            bitOffset: 28 
+            bitWidth: 3
+          PPSOUTNUM:
+            description: Number of PPS Outputs
+            bitOffset: 24 
+            bitWidth: 3
+          TXCHCNT:
+            description: Number of DMA Transmit Channels
+            bitOffset: 18 
+            bitWidth: 4
+          RXCHCNT:
+            description: Number of DMA Receive Channels
+            bitOffset: 12 
+            bitWidth: 4
+          TXQCNT:
+            description: Number of MTL Transmit Queues
+            bitOffset: 6 
+            bitWidth: 4
+          RXQCNT:
+            description: Number of MTL Receive Queues
+            bitOffset: 0 
+            bitWidth: 4
+      MACMDIOAR:
+        description: MDIO address register
+        addressOffset: 0x0200
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          PSE:
+            description: Preamble Suppression Enable
+            bitOffset: 27 
+            bitWidth: 1
+          BTB:
+            description: Back to Back transactions
+            bitOffset: 26 
+            bitWidth: 1
+          PA:
+            description: Physical Layer Address
+            bitOffset: 21 
+            bitWidth: 5
+          RDA:
+            description: Register/Device Address
+            bitOffset: 16 
+            bitWidth: 5
+          NTC:
+            description: Number of Training Clocks
+            bitOffset: 12 
+            bitWidth: 3
+          CR:
+            description: CSR Clock Range
+            bitOffset: 8 
+            bitWidth: 4
+          SKAP:
+            description: Skip Address Packet
+            bitOffset: 4 
+            bitWidth: 1
+          GOC:
+            description: MII Operation Command
+            bitOffset: 2 
+            bitWidth: 2
+          C45E:
+            description: Clause 45 PHY Enable
+            bitOffset: 1 
+            bitWidth: 1
+          MB:
+            description: MII Busy
+            bitOffset: 0 
+            bitWidth: 1
+      MACMDIODR:
+        description: MDIO data register
+        addressOffset: 0x0204
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          RA:
+            description: Register Address
+            bitOffset: 16 
+            bitWidth: 16
+          MD:
+            description: MII Data
+            bitOffset: 0 
+            bitWidth: 16
+      MACARPAR:
+        description: ARP address register
+        # TODO - this might actually be at 0xB10 based on its location in the reference manual register map
+        addressOffset: 0x0AE0
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          ARPPA:
+            description: ARP Protocol Address
+            bitOffset: 0 
+            bitWidth: 32
+      MACA0HR:
+        description: Address 0 high register
+        addressOffset: 0x0300
+        resetValue: 0x8000FFFF
+        access: read-write
+        fields:
+          AE:
+            description: Address Enable
+            bitOffset: 31 
+            bitWidth: 1
+          ADDRHI:
+            description: MAC Address0[47:32]
+            bitOffset: 0 
+            bitWidth: 16
+      MACA0LR:
+        description: Address 0 low register
+        addressOffset: 0x0304
+        resetValue: 0xFFFFFFFF
+        access: read-write
+        fields:
+          ADDRLO:
+            description: MAC Address 0 [31:0]
+            bitOffset: 0 
+            bitWidth: 32
+      MACA1LR:
+        description: Address 1 low register
+        addressOffset: 0x030C
+        resetValue: 0xFFFFFFFF
+        access: read-write
+        fields:
+          ADDRLO:
+            description: MAC Address 1 [31:0]
+            bitOffset: 0 
+            bitWidth: 32
+      MACA2LR:
+        description: Address 2 low register
+        addressOffset: 0x0314
+        resetValue: 0xFFFFFFFF
+        access: read-write
+        fields:
+          ADDRLO:
+            description: MAC Address 2 [31:0]
+            bitOffset: 0 
+            bitWidth: 32
+      MACA3LR:
+        description: Address 3 low register
+        addressOffset: 0x031C
+        resetValue: 0xFFFFFFFF
+        access: read-write
+        fields:
+          ADDRLO:
+            description: MAC Address 3 [31:0]
+            bitOffset: 0 
+            bitWidth: 32
+      MACA1HR:
+        description: Address 1 high register
+        addressOffset: 0x0308
+        resetValue: 0x0000FFFF
+        access: read-write
+        fields:
+          AE:
+            description: Address Enable
+            bitOffset: 31 
+            bitWidth: 1
+          SA:
+            description: Source Address
+            bitOffset: 30 
+            bitWidth: 1
+          MBC:
+            description: Mask Byte Control
+            bitOffset: 24 
+            bitWidth: 6
+          ADDRHI:
+            description: MAC Address1 [47:32]
+            bitOffset: 0 
+            bitWidth: 16
+      MACA2HR:
+        description: Address 2 high register
+        addressOffset: 0x0310
+        resetValue: 0x0000FFFF
+        access: read-write
+        fields:
+          AE:
+            description: Address Enable
+            bitOffset: 31 
+            bitWidth: 1
+          SA:
+            description: Source Address
+            bitOffset: 30 
+            bitWidth: 1
+          MBC:
+            description: Mask Byte Control
+            bitOffset: 24 
+            bitWidth: 6
+          ADDRHI:
+            description: MAC Address2 [47:32]
+            bitOffset: 0 
+            bitWidth: 16
+      MACA3HR:
+        description: Address 3 high register
+        addressOffset: 0x0318
+        resetValue: 0x0000FFFF
+        access: read-write
+        fields:
+          AE:
+            description: Address Enable
+            bitOffset: 31 
+            bitWidth: 1
+          SA:
+            description: Source Address
+            bitOffset: 30 
+            bitWidth: 1
+          MBC:
+            description: Mask Byte Control
+            bitOffset: 24 
+            bitWidth: 6
+          ADDRHI:
+            description: MAC Address3 [47:32]
+            bitOffset: 0 
+            bitWidth: 16
+      MACL3L4C0R:
+        description: L3 and L4 control 0 register
+        addressOffset: 0x0900
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          L4DPIM0:
+            description: Layer 4 Destination Port Inverse Match Enable
+            bitOffset: 21 
+            bitWidth: 1
+          L4DPM0:
+            description: Layer 4 Destination Port Match Enable
+            bitOffset: 20 
+            bitWidth: 1
+          L4SPIM0:
+            description: Layer 4 Source Port Inverse Match Enable
+            bitOffset: 19 
+            bitWidth: 1
+          L4SPM0:
+            description: Layer 4 Source Port Match Enable
+            bitOffset: 18 
+            bitWidth: 1
+          L4PEN0:
+            description: Layer 4 Protocol Enable
+            bitOffset: 16 
+            bitWidth: 1
+          L3HDBM0:
+            description: Layer 3 IP DA Higher Bits Match
+            bitOffset: 11 
+            bitWidth: 5
+          L3HSBM0:
+            description: Layer 3 IP SA Higher Bits Match
+            bitOffset: 6 
+            bitWidth: 5
+          L3DAIM0:
+            description: Layer 3 IP DA Inverse Match Enable
+            bitOffset: 5 
+            bitWidth: 1
+          L3DAM0:
+            description: Layer 3 IP DA Match Enable
+            bitOffset: 4 
+            bitWidth: 1
+          L3SAIM0:
+            description: Layer 3 IP SA Inverse Match Enable
+            bitOffset: 3 
+            bitWidth: 1
+          L3SAM0:
+            description: Layer 3 IP SA Match Enable
+            bitOffset: 2 
+            bitWidth: 1
+          L3PEN0:
+            description: Layer 3 Protocol Enable
+            bitOffset: 0 
+            bitWidth: 1
+      MACL4A0R:
+        description: Layer4 address filter 0 register
+        addressOffset: 0x0904
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          L4DP0:
+            description: Layer 4 Destination Port Number Field
+            bitOffset: 16 
+            bitWidth: 16
+          L4SP0:
+            description: Layer 4 Source Port Number Field
+            bitOffset: 0 
+            bitWidth: 16
+      MACL3A00R:
+        description: Layer 3 Address 0 filter 0 register
+        addressOffset: 0x0910
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          L3A00:
+            description: Layer 3 Address 0 Field
+            bitOffset: 0 
+            bitWidth: 32
+      MACL3A10R:
+        description: Layer3 address 1 filter 0 register
+        addressOffset: 0x0914
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          L3A10:
+            description: Layer 3 Address 1 Field
+            bitOffset: 0 
+            bitWidth: 32
+      MACL3A20:
+        description: Layer3 Address 2 filter 0 register
+        addressOffset: 0x0918
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          L3A20:
+            description: Layer 3 Address 2 Field
+            bitOffset: 0 
+            bitWidth: 32
+      MACL3A30:
+        description: Layer3 Address 3 filter 0 register
+        addressOffset: 0x091C
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          L3A30:
+            description: Layer 3 Address 3 Field
+            bitOffset: 0 
+            bitWidth: 32
+      MACL3L4C1R:
+        description: L3 and L4 control 1 register
+        addressOffset: 0x0930
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          L4DPIM1:
+            description: Layer 4 Destination Port Inverse Match Enable
+            bitOffset: 21 
+            bitWidth: 1
+          L4DPM1:
+            description: Layer 4 Destination Port Match Enable
+            bitOffset: 20 
+            bitWidth: 1
+          L4SPIM1:
+            description: Layer 4 Source Port Inverse Match Enable
+            bitOffset: 19 
+            bitWidth: 1
+          L4SPM1:
+            description: Layer 4 Source Port Match Enable
+            bitOffset: 18 
+            bitWidth: 1
+          L4PEN1:
+            description: Layer 4 Protocol Enable
+            bitOffset: 16 
+            bitWidth: 1
+          L3HDBM1:
+            description: Layer 3 IP DA Higher Bits Match
+            bitOffset: 11 
+            bitWidth: 5
+          L3HSBM1:
+            description: Layer 3 IP SA Higher Bits Match
+            bitOffset: 6 
+            bitWidth: 5
+          L3DAIM1:
+            description: Layer 3 IP DA Inverse Match Enable
+            bitOffset: 5 
+            bitWidth: 1
+          L3DAM1:
+            description: Layer 3 IP DA Match Enable
+            bitOffset: 4 
+            bitWidth: 1
+          L3SAIM1:
+            description: Layer 3 IP SA Inverse Match Enable
+            bitOffset: 3 
+            bitWidth: 1
+          L3SAM1:
+            description: Layer 3 IP SA Match Enable
+            bitOffset: 2 
+            bitWidth: 1
+          L3PEN1:
+            description: Layer 3 Protocol Enable
+            bitOffset: 0 
+            bitWidth: 1
+      MACL4A1R:
+        description: Layer 4 address filter 1 register
+        addressOffset: 0x0934
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          L4DP1:
+            description: Layer 4 Destination Port Number Field
+            bitOffset: 16 
+            bitWidth: 16
+          L4SP1:
+            description: Layer 4 Source Port Number Field
+            bitOffset: 0 
+            bitWidth: 16
+      MACL3A01R:
+        description: Layer3 address 0 filter 1 Register
+        addressOffset: 0x0940
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          L3A01:
+            description: Layer 3 Address 0 Field
+            bitOffset: 0 
+            bitWidth: 32
+      MACL3A11R:
+        description: Layer3 address 1 filter 1 register
+        addressOffset: 0x0944
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          L3A11:
+            description: Layer 3 Address 1 Field
+            bitOffset: 0 
+            bitWidth: 32
+      MACL3A21R:
+        description: Layer3 address 2 filter 1 Register
+        addressOffset: 0x0948
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          L3A21:
+            description: Layer 3 Address 2 Field
+            bitOffset: 0 
+            bitWidth: 32
+      MACL3A31R:
+        description: Layer3 address 3 filter 1 register
+        addressOffset: 0x94C
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          L3A31:
+            description: Layer 3 Address 3 Field
+            bitOffset: 0 
+            bitWidth: 32
+      MACTSCR:
+        description: Timestamp control Register
+        addressOffset: 0x0B00
+        resetValue: 0x00002000
+        access: read-write
+        fields:
+          TXTSSTSM:
+            description: Transmit Timestamp Status Mode
+            bitOffset: 24 
+            bitWidth: 1
+          CSC:
+            description: Enable checksum correction during OST for PTP over UDP/IPv4 packets
+            bitOffset: 19 
+            bitWidth: 1
+          TSENMACADDR:
+            description: Enable MAC Address for PTP Packet Filtering
+            bitOffset: 18 
+            bitWidth: 1
+          SNAPTYPSEL:
+            description: Select PTP packets for Taking Snapshots
+            bitOffset: 16 
+            bitWidth: 2
+          TSMSTRENA:
+            description: Enable Snapshot for Messages Relevant to Master
+            bitOffset: 15 
+            bitWidth: 1
+          TSEVNTENA:
+            description: Enable Timestamp Snapshot for Event Messages
+            bitOffset: 14 
+            bitWidth: 1
+          TSIPV4ENA:
+            description: Enable Processing of PTP Packets Sent over IPv4-UDP
+            bitOffset: 13 
+            bitWidth: 1
+          TSIPV6ENA:
+            description: Enable Processing of PTP Packets Sent over IPv6-UDP
+            bitOffset: 12 
+            bitWidth: 1
+          TSIPENA:
+            description: Enable Processing of PTP over Ethernet Packets
+            bitOffset: 11 
+            bitWidth: 1
+          TSVER2ENA:
+            description: Enable PTP Packet Processing for Version 2 Format
+            bitOffset: 10 
+            bitWidth: 1
+          TSCTRLSSR:
+            description: Timestamp Digital or Binary Rollover Control
+            bitOffset: 9 
+            bitWidth: 1
+          TSENALL:
+            description: Enable Timestamp for All Packets
+            bitOffset: 8 
+            bitWidth: 1
+          TSADDREG:
+            description: Update Addend Register
+            bitOffset: 5 
+            bitWidth: 1
+          TSUPDT:
+            description: Update Timestamp
+            bitOffset: 3 
+            bitWidth: 1
+          TSINIT:
+            description: Initialize Timestamp
+            bitOffset: 2 
+            bitWidth: 1
+          TSCFUPDT:
+            description: Fine or Coarse Timestamp Update
+            bitOffset: 1 
+            bitWidth: 1
+          TSENA:
+            description: Enable Timestamp
+            bitOffset: 0 
+            bitWidth: 1
+      MACSSIR:
+        description: Sub-second increment register
+        addressOffset: 0x0B04
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          SSINC:
+            description: Sub-second Increment Value
+            bitOffset: 16 
+            bitWidth: 8
+          SNSINC:
+            description: Sub-nanosecond Increment Value
+            bitOffset: 8 
+            bitWidth: 8
+      MACSTSR:
+        description: System time seconds register
+        addressOffset: 0x0B08
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          TSSS:
+            description: Timestamp Sub-seconds
+            bitOffset: 0 
+            bitWidth: 31
+      MACSTSUR:
+        description: System time seconds update register
+        addressOffset: 0x0B10
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          TSS:
+            description: Timestamp Seconds
+            bitOffset: 0 
+            bitWidth: 32
+      MACSTNUR:
+        description: System time nanoseconds update register
+        addressOffset: 0x0B14
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          ADDSUB:
+            description: Add or Subtract Time
+            bitOffset: 31 
+            bitWidth: 1
+          TSSS:
+            description: Timestamp Sub-seconds
+            bitOffset: 0 
+            bitWidth: 31
+      MACTSAR:
+        description: Timestamp addend register
+        addressOffset: 0x0B18
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          TSAR:
+            description: Timestamp Addend Register
+            bitOffset: 0 
+            bitWidth: 32
+      MACTSSR:
+        description: Timestamp status register
+        addressOffset: 0x0B20
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          ATSNS:
+            description: Number of Auxiliary Timestamp Snapshots
+            bitOffset: 25 
+            bitWidth: 5
+          ATSSTM:
+            description: Auxiliary Timestamp Snapshot Trigger Missed
+            bitOffset: 24 
+            bitWidth: 1
+          ATSSTN:
+            description: Auxiliary Timestamp Snapshot Trigger Identifier
+            bitOffset: 16 
+            bitWidth: 4
+          TXTSSIS:
+            description: Tx Timestamp Status Interrupt Status
+            bitOffset: 15 
+            bitWidth: 1
+          TSTRGTERR0:
+            description: Timestamp Target Time Error
+            bitOffset: 3 
+            bitWidth: 1
+          AUXTSTRIG:
+            description: Auxiliary Timestamp Trigger Snapshot
+            bitOffset: 2 
+            bitWidth: 1
+          TSTARGT0:
+            description: Timestamp Target Time Reached
+            bitOffset: 1 
+            bitWidth: 1
+          TSSOVF:
+            description: Timestamp Seconds Overflow
+            bitOffset: 0 
+            bitWidth: 1
+      MACTXTSSNR:
+        description: Tx timestamp status nanoseconds register
+        addressOffset: 0x0B30
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          TXTSSMIS:
+            description: Transmit Timestamp Status Missed
+            bitOffset: 31 
+            bitWidth: 1
+          TXTSSLO:
+            description: Transmit Timestamp Status Low
+            bitOffset: 0 
+            bitWidth: 31
+      MACTXTSSSR:
+        description: Tx timestamp status seconds register
+        addressOffset: 0x0B34
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          TXTSSHI:
+            description: Transmit Timestamp Status High
+            bitOffset: 0 
+            bitWidth: 32
+      MACACR:
+        description: Auxiliary control register
+        addressOffset: 0x0B40
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          ATSEN3:
+            description: Auxiliary Snapshot 3 Enable
+            bitOffset: 7 
+            bitWidth: 1
+          ATSEN2:
+            description: Auxiliary Snapshot 2 Enable
+            bitOffset: 6 
+            bitWidth: 1
+          ATSEN1:
+            description: Auxiliary Snapshot 1 Enable
+            bitOffset: 5 
+            bitWidth: 1
+          ATSEN0:
+            description: Auxiliary Snapshot 0 Enable
+            bitOffset: 4 
+            bitWidth: 1
+          ATSFC:
+            description: Auxiliary Snapshot FIFO Clear
+            bitOffset: 0 
+            bitWidth: 1
+      MACATSNR:
+        description: Auxiliary timestamp nanoseconds register
+        addressOffset: 0x0B48
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          AUXTSLO:
+            description: Auxiliary Timestamp
+            bitOffset: 0 
+            bitWidth: 31
+      MACATSSR:
+        description: Auxiliary timestamp seconds register
+        addressOffset: 0x0B4C
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          AUXTSHI:
+            description: Auxiliary Timestamp
+            bitOffset: 0 
+            bitWidth: 32
+      MACTSIACR:
+        description: Timestamp Ingress asymmetric correction register
+        addressOffset: 0x0B50
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          OSTIAC:
+            description: One-Step Timestamp Ingress Asymmetry Correction
+            bitOffset: 0 
+            bitWidth: 32
+      MACTSEACR:
+        description: Timestamp Egress asymmetric correction register
+        addressOffset: 0x0B54
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          OSTEAC:
+            description: One-Step Timestamp Egress Asymmetry Correction
+            bitOffset: 0 
+            bitWidth: 32
+      MACTSICNR:
+        description: Timestamp Ingress correction nanosecond register
+        addressOffset: 0x0B58
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          TSIC:
+            description: Timestamp Ingress Correction
+            bitOffset: 0 
+            bitWidth: 32
+      MACTSECNR:
+        description: Timestamp Egress correction nanosecond register
+        addressOffset: 0x0B5C
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          TSEC:
+            description: Timestamp Egress Correction
+            bitOffset: 0 
+            bitWidth: 32
+      MACPPSCR:
+        description: PPS control register
+        addressOffset: 0x0B70
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          TRGTMODSEL0:
+            description: Target Time Register Mode for PPS Output
+            bitOffset: 5 
+            bitWidth: 2
+          PPSEN0:
+            description: Flexible PPS Output Mode Enable
+            bitOffset: 4 
+            bitWidth: 1
+          PPSCTRL:
+            description: PPS Output Frequency Control
+            bitOffset: 0 
+            bitWidth: 4
+      MACPPSCR:
+        description: PPS control register
+        addressOffset: 0x0B70
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          TRGTMODSEL0:
+            description: Target Time Register Mode for PPS Output
+            bitOffset: 5 
+            bitWidth: 2
+          PPSEN0:
+            description: Flexible PPS Output Mode Enable
+            bitOffset: 4 
+            bitWidth: 1
+          PPSCMD:
+            description: Flexible PPS Output (ptp_pps_o[0]) Control
+            bitOffset: 0 
+            bitWidth: 4
+      MACPPSTTSR:
+        description: PPS target time seconds register
+        addressOffset: 0x0B80
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          TSTRH0:
+            description: PPS Target Time Seconds Register
+            bitOffset: 0 
+            bitWidth: 32
+      MACPPSTTNR:
+        description: PPS target time nanoseconds register
+        addressOffset: 0x0B84
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          TRGTBUSY0:
+            description: PPS Target Time Register Busy
+            bitOffset: 31 
+            bitWidth: 1
+          TTSL0:
+            description: Target Time Low for PPS Register
+            bitOffset: 0 
+            bitWidth: 31
+      MACPPSIR:
+        description: PPS interval register
+        addressOffset: 0x0B88
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          PPSINT0:
+            description: PPS Output Signal Interval
+            bitOffset: 0 
+            bitWidth: 32
+      MACPPSWR:
+        description: PPS width register
+        addressOffset: 0x0B8C
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          PPSWIDTH0:
+            description: PPS Output Signal Width
+            bitOffset: 0 
+            bitWidth: 32
+      MACPOCR:
+        description: PTP Offload control register
+        addressOffset: 0x0BC0
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          DN:
+            description: Domain Number
+            bitOffset: 8 
+            bitWidth: 8
+          DRRDIS:
+            description: Disable PTO Delay Request/Response response generation
+            bitOffset: 6 
+            bitWidth: 1
+          APDREQTRIG:
+            description: Automatic PTP Pdelay_Req message Trigger
+            bitOffset: 5 
+            bitWidth: 1
+          ASYNCTRIG:
+            description: Automatic PTP SYNC message Trigger
+            bitOffset: 4 
+            bitWidth: 1
+          APDREQEN:
+            description: Automatic PTP Pdelay_Req message Enable
+            bitOffset: 2 
+            bitWidth: 1
+          ASYNCEN:
+            description: Automatic PTP SYNC message Enable
+            bitOffset: 1 
+            bitWidth: 1
+          PTOEN:
+            description: PTP Offload Enable
+            bitOffset: 0 
+            bitWidth: 1
+      MACSPI0R:
+        description: PTP Source Port Identity 0 Register
+        addressOffset: 0x0BC4
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          SPI0:
+            description: Source Port Identity 0
+            bitOffset: 0 
+            bitWidth: 32
+      MACSPI1R:
+        description: PTP Source port identity 1 register
+        addressOffset: 0x0BC8
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          SPI1:
+            description: Source Port Identity 1
+            bitOffset: 0 
+            bitWidth: 32
+      MACSPI2R:
+        description: PTP Source port identity 2 register
+        addressOffset: 0x0BCC
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          SPI2:
+            description: Source Port Identity 2
+            bitOffset: 0 
+            bitWidth: 16
+      MACLMIR:
+        description: Log message interval register
+        addressOffset: 0x0BD0
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          LMPDRI:
+            description: Log Min Pdelay_Req Interval
+            bitOffset: 24 
+            bitWidth: 8
+          DRSYNCR:
+            description: Delay_Req to SYNC Ratio
+            bitOffset: 8 
+            bitWidth: 3
+          LSI:
+            description: Log Sync Interval
+            bitOffset: 0 
+            bitWidth: 8
+
+  Ethernet_MMC:
+    baseAddress: 0x40028700
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+    registers:
+      CONTROL:
+        description: MMC control register
+        addressOffset: 0x0000
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          UCDBC:
+            description: Update MMC Counters for Dropped Broadcast Packets
+            bitOffset: 8 
+            bitWidth: 1
+          CNTPRSTLVL:
+            description: Full-Half Preset
+            bitOffset: 5 
+            bitWidth: 1
+          CNTPRST:
+            description: Counters Preset
+            bitOffset: 4 
+            bitWidth: 1
+          CNTFREEZ:
+            description: MMC Counter Freeze
+            bitOffset: 3 
+            bitWidth: 1
+          RSTONRD:
+            description: Reset on Read
+            bitOffset: 2 
+            bitWidth: 1
+          CNTSTOPRO:
+            description: Counter Stop Rollover
+            bitOffset: 1 
+            bitWidth: 1
+          CNTRST:
+            description: Counters Reset
+            bitOffset: 0 
+            bitWidth: 1
+      RX_INTERRUPT:
+        description: MMC Rx interrupt register
+        addressOffset: 0x0004
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          RXLPITRCIS:
+            description: MMC Receive LPI transition counter interrupt status
+            bitOffset: 27 
+            bitWidth: 1
+          RXLPIUSCIS:
+            description: MMC Receive LPI microsecond counter interrupt status
+            bitOffset: 26 
+            bitWidth: 1
+          RXUCGPIS:
+            description: MMC Receive Unicast Good Packet Counter Interrupt Status
+            bitOffset: 17 
+            bitWidth: 1
+          RXALGNERPIS:
+            description: MMC Receive Alignment Error Packet Counter Interrupt Status
+            bitOffset: 6 
+            bitWidth: 1
+          RXCRCERPIS:
+            description: MMC Receive CRC Error Packet Counter Interrupt Status
+            bitOffset: 5 
+            bitWidth: 1
+      TX_INTERRUPT:
+        description: MMC Tx interrupt register
+        addressOffset: 0x0008
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          TXLPITRCIS:
+            description: MMC Transmit LPI transition counter interrupt status
+            bitOffset: 27 
+            bitWidth: 1
+          TXLPIUSCIS:
+            description: MMC Transmit LPI microsecond counter interrupt status
+            bitOffset: 26 
+            bitWidth: 1
+          TXGPKTIS:
+            description: MMC Transmit Good Packet Counter Interrupt Status
+            bitOffset: 21 
+            bitWidth: 1
+          TXMCOLGPIS:
+            description: MMC Transmit Multiple Collision Good Packet Counter Interrupt Status
+            bitOffset: 15 
+            bitWidth: 1
+          TXSCOLGPIS:
+            description: MMC Transmit Single Collision Good Packet Counter Interrupt Status
+            bitOffset: 14 
+            bitWidth: 1
+      RX_INTERRUPT_MASK:
+        description: MMC Rx interrupt mask register
+        addressOffset: 0x000C
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          RXLPITRCIM:
+            description: MMC Receive LPI transition counter interrupt Mask
+            bitOffset: 27 
+            bitWidth: 1
+          RXLPIUSCIM:
+            description: MMC Receive LPI microsecond counter interrupt Mask
+            bitOffset: 26 
+            bitWidth: 1
+          RXUCGPIM:
+            description: MMC Receive Unicast Good Packet Counter Interrupt Mask
+            bitOffset: 17 
+            bitWidth: 1
+          RXALGNERPIM:
+            description: MMC Receive Alignment Error Packet Counter Interrupt Mask
+            bitOffset: 6 
+            bitWidth: 1
+          RXCRCERPIM:
+            description: MMC Receive CRC Error Packet Counter Interrupt Mask
+            bitOffset: 5 
+            bitWidth: 1
+      TX_INTERRUPT_MASK:
+        description: MMC Tx interrupt mask register
+        addressOffset: 0x0010
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          TXLPITRCIM:
+            description: MMC Transmit LPI transition counter interrupt Mask
+            bitOffset: 27 
+            bitWidth: 1
+          TXLPIUSCIM:
+            description: MMC Transmit LPI microsecond counter interrupt Mask
+            bitOffset: 26 
+            bitWidth: 1
+          TXGPKTIM:
+            description: MMC Transmit Good Packet Counter Interrupt Mask
+            bitOffset: 21 
+            bitWidth: 1
+          TXMCOLGPIM:
+            description: MMC Transmit Multiple Collision Good Packet Counter Interrupt Mask
+            bitOffset: 15 
+            bitWidth: 1
+          TXSCOLGPIM:
+            description: MMC Transmit Single Collision Good Packet Counter Interrupt Mask
+            bitOffset: 14 
+            bitWidth: 1
 
 "GPIOA":
   _modify:

--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -1172,6 +1172,106 @@ _add:
             description: MAC Address3 [47:32]
             bitOffset: 0 
             bitWidth: 16
+      TX_SINGLE_COLLISION_GOOD_PACKETS:
+        description: Tx single collision good packets register
+        addressOffset: 0x074C
+        resetValue: 0x00000000
+        access: read-only
+        fields:
+          TXSNGLCOLG:
+            description: Tx Single Collision Good Packets
+            bitOffset: 0 
+            bitWidth: 32
+      TX_MULTIPLE_COLLISION_GOOD_PACKETS:
+        description: Tx multiple collision good packets register
+        addressOffset: 0x0750
+        resetValue: 0x00000000
+        access: read-only
+        fields:
+          TXMULTCOLG:
+            description: Tx Multiple Collision Good Packets
+            bitOffset: 0 
+            bitWidth: 32
+      TX_PACKET_COUNT_GOOD:
+        description: Tx packet count good register
+        addressOffset: 0x0768
+        resetValue: 0x00000000
+        access: read-only
+        fields:
+          TXPKTG:
+            description: Tx Packet Count Good
+            bitOffset: 0 
+            bitWidth: 32
+      RX_CRC_ERROR_PACKETS:
+        description: Rx CRC error packets register
+        addressOffset: 0x0794
+        resetValue: 0x00000000
+        access: read-only
+        fields:
+          RXCRCERR:
+            description: Rx CRC Error Packets
+            bitOffset: 0 
+            bitWidth: 32
+      RX_ALIGNMENT_ERROR_PACKETS:
+        description: Rx alignment error packets register
+        addressOffset: 0x0798
+        resetValue: 0x00000000
+        access: read-only
+        fields:
+          RXALGNERR:
+            description: Rx Alignment Error Packets
+            bitOffset: 0 
+            bitWidth: 32
+      RX_UNICAST_PACKETS_GOOD:
+        description: Rx unicast packets good register
+        addressOffset: 0x07C4
+        resetValue: 0x00000000
+        access: read-only
+        fields:
+          RXUCASTG:
+            description: Rx Unicast Packets Good
+            bitOffset: 0 
+            bitWidth: 32
+      TX_LPI_USEC_CNTR:
+        description: Tx LPI microsecond timer register
+        addressOffset: 0x07EC
+        resetValue: 0x00000000
+        access: read-only
+        fields:
+          TXLPIUSC:
+            description: Tx LPI Microseconds Counter
+            bitOffset: 0 
+            bitWidth: 32
+      TX_LPI_TRAN_CNTR:
+        description: Tx LPI transition counter register
+        addressOffset: 0x07F0
+        resetValue: 0x00000000
+        access: read-only
+        fields:
+          TXLPITRC:
+            description: Tx LPI Transition counter
+            bitOffset: 0 
+            bitWidth: 32
+      RX_LPI_USEC_CNTR:
+        description: Rx LPI microsecond counter register
+        addressOffset: 0x07F4
+        resetValue: 0x00000000
+        access: read-only
+        fields:
+          RXLPIUSC:
+            description: Rx LPI Microseconds Counter
+            bitOffset: 0 
+            bitWidth: 32
+      RX_LPI_TRAN_CNTR:
+        description: Rx LPI transition counter register
+        addressOffset: 0x07F8
+        resetValue: 0x00000000
+        access: read-only
+        fields:
+          RXLPITRC:
+            description: Rx LPI Transition counter
+            bitOffset: 0 
+            bitWidth: 32
       MACL3L4C0R:
         description: L3 and L4 control 0 register
         addressOffset: 0x0900

--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -10,6 +10,221 @@ _modify:
     description: "Ethernet: DMA controller operation"
 
 _add:
+  Ethernet_MTL:
+    baseAddress: 0x40028000
+    addressBlock:
+      offset: 0
+    registers:
+      MTLOMR:
+        description: Operating mode Register
+        addressOffset: 0x0C00
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          CNTCLR:
+            description: Counters Reset
+            bitOffset: 9 
+            bitWidth: 1
+          CNTPRST:
+            description: Counters Preset
+            bitOffset: 8 
+            bitWidth: 1
+          DTXSTS:
+            description: Drop Transmit Status
+            bitOffset: 1 
+            bitWidth: 1
+      MTLISR:
+        description: Interrupt status Register
+        addressOffset: 0x0C20
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          Q0IS:
+            description: Queue interrupt status
+            bitOffset: 0 
+            bitWidth: 1
+      MTLTXQOMR:
+        description: Tx queue operating mode Register
+        addressOffset: 0x0D00
+        resetValue: 0x00070008
+        access: read-write
+        fields:
+          TQS:
+            description: Transmit Queue Size
+            bitOffset: 16 
+            bitWidth: 9
+          TTC:
+            description: Transmit Threshold Control
+            bitOffset: 4 
+            bitWidth: 3
+          TXQEN:
+            description: Transmit Queue Enable
+            bitOffset: 2 
+            bitWidth: 2
+          TSF:
+            description: Transmit Store and Forward
+            bitOffset: 1 
+            bitWidth: 1
+          FTQ:
+            description: Flush Transmit Queue
+            bitOffset: 0 
+            bitWidth: 1
+      MTLTXQUR:
+        description: Tx queue underflow register
+        addressOffset: 0x0D04
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          UFCNTOVF:
+            description: Overflow Bit for Underflow Packet Counter
+            bitOffset: 11 
+            bitWidth: 1
+          UFFRMCNT:
+            description: Underflow Packet Counter
+            bitOffset: 0 
+            bitWidth: 11
+      MTLTXQDR:
+        description: Tx queue debug Register
+        addressOffset: 0x0D08
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          STXSTSF:
+            description: Number of Status Words in Tx Status FIFO of Queue
+            bitOffset: 20 
+            bitWidth: 3
+          PTXQ:
+            description: Number of Packets in the Transmit Queue
+            bitOffset: 16 
+            bitWidth: 3
+          TXSTSFSTS:
+            description: MTL Tx Status FIFO Full Status
+            bitOffset: 5 
+            bitWidth: 1
+          TXQSTS:
+            description: MTL Tx Queue Not Empty Status
+            bitOffset: 4 
+            bitWidth: 1
+          TWCSTS:
+            description: MTL Tx Queue Write Controller Status
+            bitOffset: 3 
+            bitWidth: 1
+          TRCSTS:
+            description: MTL Tx Queue Read Controller Status
+            bitOffset: 1 
+            bitWidth: 2
+          TXQPAUSED:
+            description: Transmit Queue in Pause
+            bitOffset: 0 
+            bitWidth: 1
+      MTLQICSR:
+        description: Queue interrupt control status Register
+        addressOffset: 0x0D2C
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          RXOIE:
+            description: Receive Queue Overflow Interrupt Enable
+            bitOffset: 24 
+            bitWidth: 1
+          RXOVFIS:
+            description: Receive Queue Overflow Interrupt Status
+            bitOffset: 16 
+            bitWidth: 1
+          TXUIE:
+            description: Transmit Queue Underflow Interrupt Enable
+            bitOffset: 8 
+            bitWidth: 1
+          TXUNFIS:
+            description: Transmit Queue Underflow Interrupt Status
+            bitOffset: 0 
+            bitWidth: 1
+      MTLRXQOMR:
+        description: Rx queue operating mode register
+        addressOffset: 0x0D30
+        resetValue: 0x00700000
+        access: read-write
+        fields:
+          RQS:
+            description: Receive Queue Size
+            bitOffset: 20 
+            bitWidth: 3
+          RFD:
+            description: Threshold for Deactivating Flow Control (in half-duplex and full-duplex modes)
+            bitOffset: 14 
+            bitWidth: 3
+          RFA:
+            description: Threshold for Activating Flow Control (in half-duplex and full-duplex
+            bitOffset: 8 
+            bitWidth: 3
+          EHFC:
+            description: Enable Hardware Flow Control
+            bitOffset: 7 
+            bitWidth: 1
+          DIS_TCP_EF:
+            description: Disable Dropping of TCP/IP Checksum Error Packets
+            bitOffset: 6 
+            bitWidth: 1
+          RSF:
+            description: Receive Queue Store and Forward
+            bitOffset: 5 
+            bitWidth: 1
+          FEP:
+            description: Forward Error Packets
+            bitOffset: 4 
+            bitWidth: 1
+          FUP:
+            description: Forward Undersized Good Packets
+            bitOffset: 3 
+            bitWidth: 1
+          RTC:
+            description: Receive Queue Threshold Control
+            bitOffset: 0 
+            bitWidth: 2
+      MTLRXQMPOCR:
+        description: Rx queue missed packet and overflow counter register
+        addressOffset: 0x0D34
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          MISCNTOVF:
+            description: Missed Packet Counter Overflow Bit
+            bitOffset: 27 
+            bitWidth: 1
+          MISPKTCNT:
+            description: Missed Packet Counter
+            bitOffset: 16 
+            bitWidth: 11
+          OVFCNTOVF:
+            description: Overflow Counter Overflow Bit
+            bitOffset: 11 
+            bitWidth: 1
+          OVFPKTCNT:
+            description: Overflow Packet Counter
+            bitOffset: 0 
+            bitWidth: 11
+      MTLRXQDR:
+        description: Rx queue debug register
+        addressOffset: 0x0D38
+        resetValue: 0x00000000
+        access: read-write
+        fields:
+          PRXQ:
+            description: Number of Packets in Receive Queue
+            bitOffset: 16 
+            bitWidth: 14
+          RXQSTS:
+            description: MTL Rx Queue Fill-Level Status
+            bitOffset: 4 
+            bitWidth: 2
+          RRCSTS:
+            description: MTL Rx Queue Read Controller State
+            bitOffset: 1 
+            bitWidth: 2
+          RWCSTS:
+            description: MTL Rx Queue Write Controller Active Status
+            bitOffset: 0 
+            bitWidth: 1
   Ethernet_MAC:
     baseAddress: 0x40028000
     addressBlock:

--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -1043,8 +1043,9 @@ _add:
             bitWidth: 16
       MACARPAR:
         description: ARP address register
-        # TODO - this might actually be at 0xB10 based on its location in the reference manual register map
-        addressOffset: 0x0AE0
+        # TODO - this might actually be at 0xAE0 - the reference manual says it
+        # is, but ST's own HAL and where they locate it in the map disagree.
+        addressOffset: 0x0B10
         resetValue: 0x00000000
         access: read-write
         fields:

--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -37,7 +37,7 @@ _add:
         description: Interrupt status Register
         addressOffset: 0x0C20
         resetValue: 0x00000000
-        access: read-write
+        access: read-only
         fields:
           Q0IS:
             description: Queue interrupt status
@@ -73,7 +73,7 @@ _add:
         description: Tx queue underflow register
         addressOffset: 0x0D04
         resetValue: 0x00000000
-        access: read-write
+        access: read-only
         fields:
           UFCNTOVF:
             description: Overflow Bit for Underflow Packet Counter
@@ -87,7 +87,7 @@ _add:
         description: Tx queue debug Register
         addressOffset: 0x0D08
         resetValue: 0x00000000
-        access: read-write
+        access: read-only
         fields:
           STXSTSF:
             description: Number of Status Words in Tx Status FIFO of Queue
@@ -185,7 +185,7 @@ _add:
         description: Rx queue missed packet and overflow counter register
         addressOffset: 0x0D34
         resetValue: 0x00000000
-        access: read-write
+        access: read-only
         fields:
           MISCNTOVF:
             description: Missed Packet Counter Overflow Bit
@@ -207,7 +207,7 @@ _add:
         description: Rx queue debug register
         addressOffset: 0x0D38
         resetValue: 0x00000000
-        access: read-write
+        access: read-only
         fields:
           PRXQ:
             description: Number of Packets in Receive Queue
@@ -616,9 +616,9 @@ _add:
             bitOffset: 0 
             bitWidth: 1
       MACISR:
-        description: Ethernet MAC Interupt status register
+        description: Ethernet MAC Interrupt status register
         addressOffset: 0xB0
-        access: read-write
+        access: read-only
         resetValue: 0x00000000
         fields:
           RXSTSIS:
@@ -690,7 +690,7 @@ _add:
       MACRXTXSR:
         description: Ethernet MAC Rx Tx status register
         addressOffset: 0xB8
-        access: read-write
+        access: read-only
         resetValue: 0x00000000
         fields:
           RWT:
@@ -861,7 +861,7 @@ _add:
         description: Version register
         addressOffset: 0x0110
         resetValue: 0x00003041
-        access: read-write
+        access: read-only
         fields:
           USERVER:
             description: ST-defined version
@@ -875,7 +875,7 @@ _add:
         description: Debug register
         addressOffset: 0x0114
         resetValue: 0x00000000
-        access: read-write
+        access: read-only
         fields:
           TFCSTS:
             description: MAC Transmit Packet Controller Status
@@ -897,7 +897,7 @@ _add:
         description: HW feature 1 register
         addressOffset: 0x0120
         resetValue: 0x11841904
-        access: read-write
+        access: read-only
         fields:
           L3L4FNUM:
             description: Total number of L3 or L4 Filters
@@ -955,7 +955,7 @@ _add:
         description: HW feature 2 register
         addressOffset: 0x0124
         resetValue: 0x41000000
-        access: read-write
+        access: read-only
         fields:
           AUXSNAPNUM:
             description: Number of Auxiliary Snapshot Inputs
@@ -1480,12 +1480,22 @@ _add:
         description: System time seconds register
         addressOffset: 0x0B08
         resetValue: 0x00000000
-        access: read-write
+        access: read-only
         fields:
           TSSS:
             description: Timestamp Sub-seconds
             bitOffset: 0 
             bitWidth: 31
+      MACSTNR:
+          description: System time nanoseconds register
+          addressOffset: 0x0B0C
+          resetValue: 0x00000000
+          access: read-only
+          fields:
+            TSSS:
+                description: Timestamp Sub-seconds
+                bitOffset: 0 
+                bitWidth: 31
       MACSTSUR:
         description: System time seconds update register
         addressOffset: 0x0B10
@@ -1524,7 +1534,7 @@ _add:
         description: Timestamp status register
         addressOffset: 0x0B20
         resetValue: 0x00000000
-        access: read-write
+        access: read-only
         fields:
           ATSNS:
             description: Number of Auxiliary Timestamp Snapshots
@@ -1562,7 +1572,7 @@ _add:
         description: Tx timestamp status nanoseconds register
         addressOffset: 0x0B30
         resetValue: 0x00000000
-        access: read-write
+        access: read-only
         fields:
           TXTSSMIS:
             description: Transmit Timestamp Status Missed
@@ -1576,7 +1586,7 @@ _add:
         description: Tx timestamp status seconds register
         addressOffset: 0x0B34
         resetValue: 0x00000000
-        access: read-write
+        access: read-only
         fields:
           TXTSSHI:
             description: Transmit Timestamp Status High
@@ -1612,7 +1622,7 @@ _add:
         description: Auxiliary timestamp nanoseconds register
         addressOffset: 0x0B48
         resetValue: 0x00000000
-        access: read-write
+        access: read-only
         fields:
           AUXTSLO:
             description: Auxiliary Timestamp
@@ -1622,7 +1632,7 @@ _add:
         description: Auxiliary timestamp seconds register
         addressOffset: 0x0B4C
         resetValue: 0x00000000
-        access: read-write
+        access: read-only
         fields:
           AUXTSHI:
             description: Auxiliary Timestamp
@@ -1875,7 +1885,7 @@ _add:
         description: MMC Rx interrupt register
         addressOffset: 0x0004
         resetValue: 0x00000000
-        access: read-write
+        access: read-only
         fields:
           RXLPITRCIS:
             description: MMC Receive LPI transition counter interrupt status
@@ -1901,7 +1911,7 @@ _add:
         description: MMC Tx interrupt register
         addressOffset: 0x0008
         resetValue: 0x00000000
-        access: read-write
+        access: read-only
         fields:
           TXLPITRCIS:
             description: MMC Transmit LPI transition counter interrupt status


### PR DESCRIPTION
Addresses Issue #41 

This PR pulls in all the missing ethernet registers from the stm32h7 reference manual (RM0433 https://www.st.com/resource/en/reference_manual/dm00314099.pdf)

Some things to note - this ethernet peripheral's registers are grouped significantly differently from others in the STM32 family. I've reproduced the DMA, MAC, MTL register groups from the manual, but added a separate MMC group, as previous family members seem to have had.

There are also a number of ethernet statistic registers such as "TX_PACKET_COUNT_GOOD" which do not share the "MAC" register prefix - I have left them in the "Ethernet_MAC" register group.

I also noticed an aberration in addressing for the MACARPAR register - it looks from the register map as if it should be at offset 0xB10, but the manual is consistent in placing it at 0xAE0. ST's own HAL code puts it at 0xB10 (https://raw.githubusercontent.com/fhsakaci/STM32H743-LwIP/master/STM32Cube_FW_H7_V1.3.0/Drivers/CMSIS/Device/ST/STM32H7xx/Include/stm32h743xx.h), so I've chalked that up as an error in the reference manual.

Let me know if there are any changes I should make or if you'd like the commits squashed. :)