### PR TITLE
Add IWDG peripherals to the stm32f0xx family

### DIFF
--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -5,3 +5,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -14,3 +14,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -7,3 +7,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -7,3 +7,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/peripherals/iwdg/iwdg.yaml
+++ b/peripherals/iwdg/iwdg.yaml
@@ -1,0 +1,23 @@
+# IWDG peripheral.
+# Documented from stm32f0x1 reference manual
+
+IWDG:
+  KR:
+    KEY:
+      Enable: [21845, "Enable access to PR, RLR and WINR registers (0x5555)"]
+      Reset: [43690, "Reset the watchdog value (0xAAAA)"]
+      Start: [52428, "Start the watchdog (0xCCCC)"]
+  PR:
+    PR:
+      DivideBy4: [0, "Divider /4"]
+      DivideBy8: [1, "Divider /8"]
+      DivideBy16: [2, "Divider /16"]
+      DivideBy32: [3, "Divider /32"]
+      DivideBy64: [4, "Divider /64"]
+      DivideBy128: [5, "Divider /128"]
+      DivideBy256: [6, "Divider /256"]
+      DivideBy256bis: [7, "Divider /256"]
+  RLR:
+    RL: [0, 4095]
+  WINR:
+    WIN: [0, 4095]


### PR DESCRIPTION
Documents the IWDG fields and add it to the devices of the STM32F0 familly.