### PR TITLE
Add advanced CRC peripheral

### DIFF
--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -2,6 +2,6 @@ _svd: ../svd/stm32f0x0.svd
 
 _include:
  - ../peripherals/gpio/gpio_v2.yaml
- - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -3,5 +3,6 @@ _svd: ../svd/stm32f0x0.svd
 _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -11,6 +11,6 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml
- - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -12,5 +12,6 @@ _include:
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -5,5 +5,6 @@ _include:
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -4,6 +4,6 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml
- - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -5,5 +5,6 @@ _include:
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -4,6 +4,6 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml
- - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/peripherals/crc/crc_advanced.yaml
+++ b/peripherals/crc/crc_advanced.yaml
@@ -1,0 +1,18 @@
+# CRC peripheral with reversal features.
+# Documented from STM32F0xx reference manual.
+
+_include:
+ - ./crc_basic.yaml
+
+CRC:
+  CR:
+    REV_IN:
+      Normal: [0, "Bit order not affected"]
+      Byte: [1, "Bit reversal done by byte"]
+      HalfWord: [2, "Bit reversal done by half-word"]
+      Word: [3, "Bit reversal done by word"]
+    REV_OUT:
+      Normal: [0, "Bit order not affected"]
+      Reversed: [1, "Bit reversed output"]
+  INIT:
+    INIT: [0, 4294967295]

--- a/peripherals/crc/crc_with_polysize.yaml
+++ b/peripherals/crc/crc_with_polysize.yaml
@@ -3,7 +3,7 @@
 CRC:
   CR:
     POLYSIZE:
-      32Bit: [0, "32-bit polynomial"]
-      16Bit: [1, "16-bit polynomial"]
-      8Bit: [2, "8-bit polynomial"]
-      7Bit: [3, "7-bit polynomial"]
+      Polysize32: [0, "32-bit polynomial"]
+      Polysize16: [1, "16-bit polynomial"]
+      Polysize8: [2, "8-bit polynomial"]
+      Polysize7: [3, "7-bit polynomial"]

--- a/peripherals/crc/crc_with_polysize.yaml
+++ b/peripherals/crc/crc_with_polysize.yaml
@@ -1,0 +1,9 @@
+# CRC peripheral with polysize feature
+
+CRC:
+  CR:
+    POLYSIZE:
+      32Bit: [0, "32-bit polynomial"]
+      16Bit: [1, "16-bit polynomial"]
+      8Bit: [2, "8-bit polynomial"]
+      7Bit: [3, "7-bit polynomial"]


### PR DESCRIPTION
Extends the basic CRC with reversal mode fields. This peripheral is used in at least the STM32F0 familly. Not all devices have this mode but it seems there is only on svd files per family. So it describe registers and fields that doesn't appear in all devices.

I have documented the POLYSIZE field has well, but I don't know where to put it. Is storing it on `crc_with_polysize.yaml` and include it on the devices that has it seems a good ideas? Please let me know.