### PR TITLE
Documents EWI field on WWDG CFR registers

### DIFF
--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -6,6 +6,16 @@ _modify:
   C_ADC:
     name: ADC_Common
 
+# Registers name are prefixed with WWDG_. Use common names.
+WWDG:
+  _modify:
+    WWDG_CR:
+      name: CR
+    WWDG_CFR:
+      name: CFR
+    WWDG_SR:
+      name: SR
+
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - common_patches/dma_fcr_wo.yaml

--- a/peripherals/wwdg/wwdg.yaml
+++ b/peripherals/wwdg/wwdg.yaml
@@ -15,6 +15,9 @@ WWDG:
       Div4: [2, "Counter clock (PCLK1 div 4096) div 4"]
       Div8: [3, "Counter clock (PCLK1 div 4096) div 8"]
     W: [0, 127]
+    EWI:
+      _write:
+        Enable: [1, "interrupt occurs whenever the counter reaches the value 0x40"]
   SR:
     EWIF:
       _read:


### PR DESCRIPTION
Also rename badly named WWDG registers on STM32F7x3.