### PR TITLE
Add a sticky header and first columns to Peripheral Compare page

### DIFF
--- a/scripts/htmlcomparesvd.py
+++ b/scripts/htmlcomparesvd.py
@@ -91,9 +91,27 @@ def who_has_what_register_fields(parts, peripheral, register):
 
 
 def html_table_peripherals(parts, peripherals):
-    out = ["<table><thead><tr><th>Peripheral</th><th>Address</th>"]
+    out = ["""
+    <style>
+    table thead tr {
+        position: sticky;
+        top: 0;
+        z-index: 5;
+        background: white;
+    }
+    td:first-child,
+    th:first-child {
+        position: sticky;
+        left: 0;
+        z-index: 6;
+        background: white;
+    }
+    </style>
+    """]
+    out.append("<table><thead><tr><th>Peripheral</th><th>Address</th>")
     for part in parts:
         out.append("<th>{}</th>".format(part['name']))
+    out.append("</thead><tbody>")
     for periph in sorted(peripherals.keys()):
         name, base = periph
         base = "0x{:08X}".format(base)
@@ -106,7 +124,7 @@ def html_table_peripherals(parts, peripherals):
             else:
                 out.append('<td align=center bgcolor="#ffcccc">&#10008;</td>')
         out.append("</tr>")
-    out.append("</tr></thead><tbody>")
+    out.append("</tr>")
     out.append("</tbody></table>")
     return "\n".join(out)
 

--- a/scripts/htmlcomparesvd.py
+++ b/scripts/htmlcomparesvd.py
@@ -91,6 +91,11 @@ def who_has_what_register_fields(parts, peripheral, register):
 
 def html_page(table):
     out = ["""
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="UTF-8">
+    </head>
     <style>
     table thead tr {
         position: sticky;
@@ -106,8 +111,9 @@ def html_page(table):
         background: white;
     }
     </style>
-    """]
+    <body>"""]
     out.append(table)
+    out.append("</body></html>")
     return "\n".join(out)
 
 def html_table_peripherals(parts, peripherals):

--- a/scripts/htmlcomparesvd.py
+++ b/scripts/htmlcomparesvd.py
@@ -89,8 +89,7 @@ def who_has_what_register_fields(parts, peripheral, register):
                     fields[name].append(part['name'])
     return fields
 
-
-def html_table_peripherals(parts, peripherals):
+def html_page(table):
     out = ["""
     <style>
     table thead tr {
@@ -108,6 +107,11 @@ def html_table_peripherals(parts, peripherals):
     }
     </style>
     """]
+    out.append(table)
+    return "\n".join(out)
+
+def html_table_peripherals(parts, peripherals):
+    out=[]
     out.append("<table><thead><tr><th>Peripheral</th><th>Address</th>")
     for part in parts:
         out.append("<th>{}</th>".format(part['name']))
@@ -180,18 +184,18 @@ def html_tables(parts):
     peripherals = who_has_what_peripherals(parts)
     files = {}
     peripheral_table = html_table_peripherals(parts, peripherals)
-    files["index.html"] = peripheral_table
+    files["index.html"] = html_page(peripheral_table)
     for pname in peripherals:
         registers = who_has_what_peripheral_registers(parts, pname)
         register_table = html_table_registers(parts, pname, registers)
         filename = "{}_0x{:08X}.html".format(pname[0], pname[1])
-        files[filename] = register_table
+        files[filename] = html_page(register_table)
         for rname in registers:
             fields = who_has_what_register_fields(parts, pname, rname)
             field_table = html_table_fields(parts, pname, rname, fields)
             filename = "{}_0x{:08X}_{}_0x{:04X}.html".format(
                 pname[0], pname[1], rname[1], rname[0])
-            files[filename] = field_table
+            files[filename] = html_page(field_table)
     return files
 
 

--- a/scripts/htmlcomparesvd.py
+++ b/scripts/htmlcomparesvd.py
@@ -122,7 +122,7 @@ def html_table_peripherals(parts, peripherals):
     out=[]
     out.append("<table><thead><tr><th>Peripheral</th><th>Address</th>")
     for part in parts:
-        out.append("<th>{}</th>".format(part['name']))
+        out.append("<th>{}</th>".format(part['name'].replace('svd/', '')))
     out.append("</thead><tbody>")
     for periph in sorted(peripherals.keys()):
         name, base = periph
@@ -144,7 +144,7 @@ def html_table_peripherals(parts, peripherals):
 def html_table_registers(parts, peripheral, registers):
     out = ["<table><thead><tr><th>Register</th><th>Offset</th>"]
     for part in parts:
-        out.append("<th>{}</th>".format(part['name']))
+        out.append("<th>{}</th>".format(part['name'].replace('svd/', '')))
     out.append("</thead><tbody>")
     for reg in sorted(registers.keys()):
         offset, name = reg
@@ -167,7 +167,7 @@ def html_table_registers(parts, peripheral, registers):
 def html_table_fields(parts, peripheral, register, fields):
     out = ["<table><thead><tr><th>Field</th><th>Offset</th><th>Width</th>"]
     for part in parts:
-        out.append("<th>{}</th>".format(part['name']))
+        out.append("<th>{}</th>".format(part['name'].replace('svd/', '')))
     out.append("</thead><tbody>")
     for field in reversed(sorted(fields.keys())):
         offset, width, name = field

--- a/scripts/htmlcomparesvd.py
+++ b/scripts/htmlcomparesvd.py
@@ -104,8 +104,7 @@ table thead tr th {
     z-index: 6;
     background: white;
 }
-td:first-child,
-th:first-child {
+td:first-child {
     position: sticky;
     left: 0;
     z-index: 5;

--- a/scripts/htmlcomparesvd.py
+++ b/scripts/htmlcomparesvd.py
@@ -89,13 +89,14 @@ def who_has_what_register_fields(parts, peripheral, register):
                     fields[name].append(part['name'])
     return fields
 
-def html_page(table):
+def html_page(title, table):
     out = ["""
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="UTF-8">
-</head>
+    <meta charset="UTF-8">"""]
+    out.append('<title>{}</title>'.format(title))
+    out.append("""</head>
 <style>
 table thead tr {
     position: sticky;
@@ -111,7 +112,8 @@ th:first-child {
     background: white;
 }
 </style>
-<body>"""]
+<body>""")
+    out.append('<h1>{}</h1>'.format(title))
     out.append(table)
     out.append("</body></html>")
     return "\n".join(out)
@@ -140,8 +142,7 @@ def html_table_peripherals(parts, peripherals):
 
 
 def html_table_registers(parts, peripheral, registers):
-    out = ["<h1>Registers In {} 0x{:08X}</h1>".format(*peripheral),
-           "<table><thead><tr><th>Register</th><th>Offset</th>"]
+    out = ["<table><thead><tr><th>Register</th><th>Offset</th>"]
     for part in parts:
         out.append("<th>{}</th>".format(part['name']))
     out.append("</thead><tbody>")
@@ -164,9 +165,7 @@ def html_table_registers(parts, peripheral, registers):
 
 
 def html_table_fields(parts, peripheral, register, fields):
-    out = ["<h1>Fields In {}_{} (0x{:08X}, 0x{:04X})</h1>".format(
-           peripheral[0], register[1], peripheral[1], register[0]),
-           "<table><thead><tr><th>Field</th><th>Offset</th><th>Width</th>"]
+    out = ["<table><thead><tr><th>Field</th><th>Offset</th><th>Width</th>"]
     for part in parts:
         out.append("<th>{}</th>".format(part['name']))
     out.append("</thead><tbody>")
@@ -190,18 +189,22 @@ def html_tables(parts):
     peripherals = who_has_what_peripherals(parts)
     files = {}
     peripheral_table = html_table_peripherals(parts, peripherals)
-    files["index.html"] = html_page(peripheral_table)
+    peripheral_title = "Compare peripherals"
+    files["index.html"] = html_page(peripheral_title, peripheral_table)
     for pname in peripherals:
         registers = who_has_what_peripheral_registers(parts, pname)
         register_table = html_table_registers(parts, pname, registers)
+        register_title = "Registers In {} 0x{:08X}".format(*pname)
         filename = "{}_0x{:08X}.html".format(pname[0], pname[1])
-        files[filename] = html_page(register_table)
+        files[filename] = html_page(register_title, register_table)
         for rname in registers:
             fields = who_has_what_register_fields(parts, pname, rname)
             field_table = html_table_fields(parts, pname, rname, fields)
+            field_title = "Fields In {}_{} (0x{:08X}, 0x{:04X})".format(
+                pname[0], rname[1], pname[1], rname[0])
             filename = "{}_0x{:08X}_{}_0x{:04X}.html".format(
                 pname[0], pname[1], rname[1], rname[0])
-            files[filename] = html_page(field_table)
+            files[filename] = html_page(field_title, field_table)
     return files
 
 

--- a/scripts/htmlcomparesvd.py
+++ b/scripts/htmlcomparesvd.py
@@ -101,14 +101,14 @@ def html_page(title, table):
 table thead tr {
     position: sticky;
     top: 0;
-    z-index: 5;
+    z-index: 6;
     background: white;
 }
 td:first-child,
 th:first-child {
     position: sticky;
     left: 0;
-    z-index: 6;
+    z-index: 5;
     background: white;
 }
 </style>

--- a/scripts/htmlcomparesvd.py
+++ b/scripts/htmlcomparesvd.py
@@ -98,7 +98,7 @@ def html_page(title, table):
     out.append('<title>{}</title>'.format(title))
     out.append("""</head>
 <style>
-table thead tr {
+table thead tr th {
     position: sticky;
     top: 0;
     z-index: 6;

--- a/scripts/htmlcomparesvd.py
+++ b/scripts/htmlcomparesvd.py
@@ -134,6 +134,7 @@ def html_table_registers(parts, peripheral, registers):
            "<table><thead><tr><th>Register</th><th>Offset</th>"]
     for part in parts:
         out.append("<th>{}</th>".format(part['name']))
+    out.append("</thead><tbody>")
     for reg in sorted(registers.keys()):
         offset, name = reg
         offset = "0x{:04X}".format(offset)
@@ -147,7 +148,7 @@ def html_table_registers(parts, peripheral, registers):
             else:
                 out.append('<td align=center bgcolor="#ffcccc">&#10008;</td>')
         out.append("</tr>")
-    out.append("</tr></thead><tbody>")
+    out.append("</tr>")
     out.append("</tbody></table>")
     return "\n".join(out)
 
@@ -158,6 +159,7 @@ def html_table_fields(parts, peripheral, register, fields):
            "<table><thead><tr><th>Field</th><th>Offset</th><th>Width</th>"]
     for part in parts:
         out.append("<th>{}</th>".format(part['name']))
+    out.append("</thead><tbody>")
     for field in reversed(sorted(fields.keys())):
         offset, width, name = field
         field_parts = fields[field]
@@ -169,7 +171,7 @@ def html_table_fields(parts, peripheral, register, fields):
             else:
                 out.append('<td align=center bgcolor="#ffcccc">&#10008;</td>')
         out.append("</tr>")
-    out.append("</tr></thead><tbody>")
+    out.append("</tr>")
     out.append("</tbody></table>")
     return "\n".join(out)
 

--- a/scripts/htmlcomparesvd.py
+++ b/scripts/htmlcomparesvd.py
@@ -91,27 +91,27 @@ def who_has_what_register_fields(parts, peripheral, register):
 
 def html_page(table):
     out = ["""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset="UTF-8">
-    </head>
-    <style>
-    table thead tr {
-        position: sticky;
-        top: 0;
-        z-index: 5;
-        background: white;
-    }
-    td:first-child,
-    th:first-child {
-        position: sticky;
-        left: 0;
-        z-index: 6;
-        background: white;
-    }
-    </style>
-    <body>"""]
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+</head>
+<style>
+table thead tr {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    background: white;
+}
+td:first-child,
+th:first-child {
+    position: sticky;
+    left: 0;
+    z-index: 6;
+    background: white;
+}
+</style>
+<body>"""]
     out.append(table)
     out.append("</body></html>")
     return "\n".join(out)


### PR DESCRIPTION
Helps a lot when searching on which family peripheral exists. CSS only implementation. Tested on firefox.  
The styling can be improve, but first let me know if that seems a good idea.