### PR TITLE
Patching typo on the STM32L chips

### DIFF
--- a/devices/common_patches/gpio_with_OSPEEDER.yaml
+++ b/devices/common_patches/gpio_with_OSPEEDER.yaml
@@ -1,0 +1,7 @@
+# This is a GPIO patch for the OSPEEDER typo
+
+"GPIO*":
+  _modify:
+    OSPEEDER:
+      name: OSPEEDR
+      displayName: OSPEEDR

--- a/devices/stm32l100.yaml
+++ b/devices/stm32l100.yaml
@@ -19,3 +19,5 @@ _include:
  - ../peripherals/spi/spi_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../devices/common_patches/gpio_with_OSPEEDER.yaml
+ - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32l151.yaml
+++ b/devices/stm32l151.yaml
@@ -18,3 +18,5 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../devices/common_patches/gpio_with_OSPEEDER.yaml
+ - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32l162.yaml
+++ b/devices/stm32l162.yaml
@@ -18,3 +18,5 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../devices/common_patches/gpio_with_OSPEEDER.yaml
+ - ../peripherals/gpio/gpio_v2.yaml


### PR DESCRIPTION
This patches the typo and allows the general GPIO patch 'gpio_v2.yaml'. This also fixes issue #53.