### PR TITLE
Documents some Timer peripherals

### DIFF
--- a/devices/common_patches/rename_TIM2_CCR3_CCR3.yaml
+++ b/devices/common_patches/rename_TIM2_CCR3_CCR3.yaml
@@ -1,0 +1,7 @@
+# Rename badly named 
+
+"TIM[23]":
+  CCR3:
+    _modify:
+      CCR1:
+        name: CCR3

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -10,3 +10,4 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/iwdg/iwdg.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -9,3 +9,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/iwdg/iwdg.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -1,6 +1,7 @@
 _svd: ../svd/stm32f0x0.svd
 
 _include:
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_advanced.yaml

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -2,6 +2,7 @@ _svd: ../svd/stm32f0x0.svd
 
 _include:
  - ../peripherals/tim/tim_basic.yaml
+ - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_advanced.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -8,6 +8,7 @@ Flash:
         bitWidth: 1
 
 _include:
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -18,3 +18,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/iwdg/iwdg.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -20,3 +20,4 @@ _include:
  - ../peripherals/iwdg/iwdg.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -19,3 +19,4 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/iwdg/iwdg.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -12,3 +12,4 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/iwdg/iwdg.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -1,6 +1,7 @@
 _svd: ../svd/stm32f0x2.svd
 
 _include:
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -11,3 +11,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/iwdg/iwdg.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -13,3 +13,4 @@ _include:
  - ../peripherals/iwdg/iwdg.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -1,6 +1,7 @@
 _svd: ../svd/stm32f0x8.svd
 
 _include:
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -12,3 +12,4 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/iwdg/iwdg.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -11,3 +11,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/iwdg/iwdg.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -13,3 +13,4 @@ _include:
  - ../peripherals/iwdg/iwdg.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f100.yaml
+++ b/devices/stm32f100.yaml
@@ -15,3 +15,4 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_f1.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f100.yaml
+++ b/devices/stm32f100.yaml
@@ -14,3 +14,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_f1.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32f100.yaml
+++ b/devices/stm32f100.yaml
@@ -16,3 +16,4 @@ _include:
  - ../peripherals/gpio/gpio_f1.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_16bit.yaml

--- a/devices/stm32f101.yaml
+++ b/devices/stm32f101.yaml
@@ -36,3 +36,4 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_f1.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_16bit.yaml

--- a/devices/stm32f101.yaml
+++ b/devices/stm32f101.yaml
@@ -35,3 +35,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_f1.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f102.yaml
+++ b/devices/stm32f102.yaml
@@ -26,3 +26,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_f1.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f102.yaml
+++ b/devices/stm32f102.yaml
@@ -27,3 +27,4 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_f1.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_16bit.yaml

--- a/devices/stm32f103.yaml
+++ b/devices/stm32f103.yaml
@@ -34,3 +34,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_f1.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f103.yaml
+++ b/devices/stm32f103.yaml
@@ -35,3 +35,4 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_f1.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_16bit.yaml

--- a/devices/stm32f107.yaml
+++ b/devices/stm32f107.yaml
@@ -36,3 +36,4 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_f1.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_16bit.yaml

--- a/devices/stm32f107.yaml
+++ b/devices/stm32f107.yaml
@@ -35,3 +35,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_f1.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f215.yaml
+++ b/devices/stm32f215.yaml
@@ -30,3 +30,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f215.yaml
+++ b/devices/stm32f215.yaml
@@ -31,3 +31,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f217.yaml
+++ b/devices/stm32f217.yaml
@@ -30,3 +30,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f217.yaml
+++ b/devices/stm32f217.yaml
@@ -31,3 +31,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -30,3 +30,4 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -29,3 +29,4 @@ _include:
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -28,3 +28,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/gpio/gpio_v2.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -16,3 +16,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -17,3 +17,4 @@ _include:
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -18,3 +18,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -16,3 +16,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -17,3 +17,4 @@ _include:
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -18,3 +18,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -6,3 +6,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -7,3 +7,4 @@ _include:
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -5,3 +5,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -8,3 +8,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -9,3 +9,4 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -7,3 +7,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -7,3 +7,4 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -8,3 +8,4 @@ _include:
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -6,3 +6,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32f401.yaml
+++ b/devices/stm32f401.yaml
@@ -29,3 +29,4 @@ _include:
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -74,3 +74,4 @@ _include:
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -73,3 +73,4 @@ _include:
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -108,3 +108,4 @@ _include:
  - ../peripherals/usart/uart_common.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -109,3 +109,4 @@ _include:
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f410.yaml
+++ b/devices/stm32f410.yaml
@@ -34,3 +34,4 @@ _include:
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f411.yaml
+++ b/devices/stm32f411.yaml
@@ -29,3 +29,4 @@ _include:
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -47,3 +47,4 @@ _include:
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -46,3 +46,4 @@ _include:
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -41,3 +41,4 @@ _include:
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -72,3 +72,4 @@ _include:
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -73,3 +73,4 @@ _include:
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -72,3 +72,4 @@ _include:
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -73,3 +73,4 @@ _include:
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -55,3 +55,4 @@ _include:
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -54,3 +54,4 @@ _include:
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -60,3 +60,4 @@ _include:
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -61,3 +61,4 @@ _include:
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -20,3 +20,4 @@ _include:
  - ../peripherals/pwr/pwr_f7.yaml
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -21,3 +21,4 @@ _include:
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -30,3 +30,4 @@ _include:
  - ../peripherals/pwr/pwr_f7.yaml
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -31,3 +31,4 @@ _include:
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f7x5.yaml
+++ b/devices/stm32f7x5.yaml
@@ -146,3 +146,4 @@ _include:
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f7x5.yaml
+++ b/devices/stm32f7x5.yaml
@@ -145,3 +145,4 @@ _include:
  - ../peripherals/pwr/pwr_f7.yaml
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -129,3 +129,4 @@ _include:
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -128,3 +128,4 @@ _include:
  - ../peripherals/pwr/pwr_f7.yaml
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -294,3 +294,4 @@ _include:
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -293,3 +293,4 @@ _include:
  - ../peripherals/pwr/pwr_f7.yaml
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -281,3 +281,4 @@ _include:
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -280,3 +280,4 @@ _include:
  - ../peripherals/pwr/pwr_f7.yaml
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -260,3 +260,4 @@ _include:
  - common_patches/dma_fcr_wo.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/gpio/gpio_v2.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -261,3 +261,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -4,3 +4,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -5,3 +5,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -5,3 +5,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -6,3 +6,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -5,3 +5,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -6,3 +6,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32l100.yaml
+++ b/devices/stm32l100.yaml
@@ -13,6 +13,7 @@ CRC:
         name: IDR
 
 _include:
+ - ./common_patches/rename_TIM2_CCR3_CCR3.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/crc/crc_basic.yaml
@@ -22,3 +23,4 @@ _include:
  - ../devices/common_patches/gpio_with_OSPEEDER.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_16bit.yaml

--- a/devices/stm32l100.yaml
+++ b/devices/stm32l100.yaml
@@ -21,3 +21,4 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../devices/common_patches/gpio_with_OSPEEDER.yaml
  - ../peripherals/gpio/gpio_v2.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32l151.yaml
+++ b/devices/stm32l151.yaml
@@ -13,6 +13,7 @@ CRC:
         name: IDR
 
 _include:
+ - ./common_patches/rename_TIM2_CCR3_CCR3.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/crc/crc_basic.yaml
@@ -21,3 +22,4 @@ _include:
  - ../devices/common_patches/gpio_with_OSPEEDER.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_16bit.yaml

--- a/devices/stm32l151.yaml
+++ b/devices/stm32l151.yaml
@@ -20,3 +20,4 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../devices/common_patches/gpio_with_OSPEEDER.yaml
  - ../peripherals/gpio/gpio_v2.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32l162.yaml
+++ b/devices/stm32l162.yaml
@@ -13,6 +13,7 @@ CRC:
         name: IDR
 
 _include:
+ - ./common_patches/rename_TIM2_CCR3_CCR3.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/crc/crc_basic.yaml
@@ -21,3 +22,4 @@ _include:
  - ../devices/common_patches/gpio_with_OSPEEDER.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_16bit.yaml

--- a/devices/stm32l162.yaml
+++ b/devices/stm32l162.yaml
@@ -20,3 +20,4 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../devices/common_patches/gpio_with_OSPEEDER.yaml
  - ../peripherals/gpio/gpio_v2.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -27,3 +27,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -26,3 +26,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -25,3 +25,4 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -27,3 +27,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -26,3 +26,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -25,3 +25,4 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -17,3 +17,4 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -18,3 +18,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -19,3 +19,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -17,3 +17,4 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -18,3 +18,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -19,3 +19,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -20,3 +20,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -18,3 +18,4 @@ _include:
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim16.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -19,3 +19,4 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim16.yaml
+ - ../peripherals/tim/tim6.yaml

--- a/peripherals/tim/tim16.yaml
+++ b/peripherals/tim/tim16.yaml
@@ -29,14 +29,14 @@
       High: [1, "OC1=1 (after a dead-time if OC1N is implemented) when MOE=0"]
   DIER:
     CC1IE:
-      Disable: [0, "CC1 interrupt disabled"]
-      Enable: [1, "CC1 interrupt enabled"]
+      Disabled: [0, "CC1 interrupt disabled"]
+      Enabled: [1, "CC1 interrupt enabled"]
     COMIE:
-      Disable: [0, "COM interrupt disabled"]
-      Enable: [1, "COM interrupt enabled"]
+      Disabled: [0, "COM interrupt disabled"]
+      Enabled: [1, "COM interrupt enabled"]
     BIE:
-      Disable: [0, "Break interrupt disabled"]
-      Enable: [1, "Break interrupt enabled"]
+      Disabled: [0, "Break interrupt disabled"]
+      Enabled: [1, "Break interrupt enabled"]
     CC1DE:
-      Disable: [0, "CC1 DMA request disabled"]
-      Enable: [1, "CC1 DMA request enabled"]
+      Disabled: [0, "CC1 DMA request disabled"]
+      Enabled: [1, "CC1 DMA request enabled"]

--- a/peripherals/tim/tim16.yaml
+++ b/peripherals/tim/tim16.yaml
@@ -1,0 +1,42 @@
+# TIM16 and TIM17 peripherals
+# All devices that has TIM16 has TIM17 except stm32l4x{1,2,3} where only TIM16
+# exists.
+#
+
+"TIM16":
+  CR1:
+    OPM:
+      NotStopped: [0, "Not stopped at update event"]
+      Stopped: [1, "Counter stops counting at next update event"]
+    ARPE:
+      NotBuffered: [0, "TIMx_ARR register is not buffered"]
+      Buffered: [1, "TIMx_ARR register is buffered"]
+  CR2:
+    CCPC:
+      NotPreloaded: [0, "CCxE, CCxNE and OCxM bits are not preloaded"]
+      Preloaded: [1, "CCxE, CCxNE and OCxM bits are preloaded"]
+    CCUS:
+      WithoutRisingEdge: [0, "Capture/compare are updated only by setting the COMG bit"]
+      WithRisingEdge: [1, "Capture/compare are updated by setting the COMG bit or when an rising edge occurs on TRGI"] 
+    CCDS:
+      OnCompare: [0, "CCx DMA request sent when CCx event occurs"]
+      OnUpdate: [0, "CCx DMA request sent when update event occurs"]
+    OIS1N:
+      Low: [0, "OC1N=0 after a dead-time when MOE=0"]
+      High: [0, "OC1N=1 after a dead-time when MOE=0"]
+    OIS1:
+      Low: [0, "OC1=0 (after a dead-time if OC1N is implemented) when MOE=0"]
+      High: [1, "OC1=1 (after a dead-time if OC1N is implemented) when MOE=0"]
+  DIER:
+    CC1IE:
+      Disable: [0, "CC1 interrupt disabled"]
+      Enable: [1, "CC1 interrupt enabled"]
+    COMIE:
+      Disable: [0, "COM interrupt disabled"]
+      Enable: [1, "COM interrupt enabled"]
+    BIE:
+      Disable: [0, "Break interrupt disabled"]
+      Enable: [1, "Break interrupt enabled"]
+    CC1DE:
+      Disable: [0, "CC1 DMA request disabled"]
+      Enable: [1, "CC1 DMA request enabled"]

--- a/peripherals/tim/tim16.yaml
+++ b/peripherals/tim/tim16.yaml
@@ -16,7 +16,7 @@
       NotPreloaded: [0, "CCxE, CCxNE and OCxM bits are not preloaded"]
       Preloaded: [1, "CCxE, CCxNE and OCxM bits are preloaded"]
     CCUS:
-      WithoutRisingEdge: [0, "Capture/compare are updated only by setting the COMG bit"]
+      Default: [0, "Capture/compare are updated only by setting the COMG bit"]
       WithRisingEdge: [1, "Capture/compare are updated by setting the COMG bit or when an rising edge occurs on TRGI"] 
     CCDS:
       OnCompare: [0, "CCx DMA request sent when CCx event occurs"]

--- a/peripherals/tim/tim2_16bit.yaml
+++ b/peripherals/tim/tim2_16bit.yaml
@@ -1,6 +1,9 @@
 # 16bit TIM2 peripheral
 # Present on stm32f1 and stm32l1 families
 
+_include:
+  - ./tim2_common.yaml
+
 "TIM[23]":
   CNT:
     CNT: [0, 65535]

--- a/peripherals/tim/tim2_16bit.yaml
+++ b/peripherals/tim/tim2_16bit.yaml
@@ -1,0 +1,16 @@
+# 16bit TIM2 peripheral
+# Present on stm32f1 and stm32l1 families
+
+"TIM[23]":
+  CNT:
+    CNT: [0, 65535]
+  ARR:
+    ARR: [0, 65535]
+  CCR1:
+    CCR1: [0, 65535]
+  CCR2:
+    CCR2: [0, 65535]
+  CCR3:
+    CCR3: [0, 65535]
+  CCR4:
+    CCR4: [0, 65535]

--- a/peripherals/tim/tim2_32bit.yaml
+++ b/peripherals/tim/tim2_32bit.yaml
@@ -4,6 +4,8 @@
 # TIM3 is present on all devices with TIM2 except STML4x3 family.
 # TIM3 is present on stm32f0x0.
 
+_include:
+  - ./tim2_common.yaml
 
 "TIM[23]":
   CNT:

--- a/peripherals/tim/tim2_32bit.yaml
+++ b/peripherals/tim/tim2_32bit.yaml
@@ -23,9 +23,49 @@
     _modify:
       ARR_H:
         name: ARRH
-        #value: [0, 65536]
+        description: "Auto-reload value"
       ARR_L: 
         name: ARRL
     _merge:
       - "ARR*"
-    ARR: [0, 65536]
+    ARR: [0, 4294967295]
+  CCR1:
+    _modify:
+      CCR1_H:
+        name: CCR1H
+        description: "Capture/Compare 1 value"
+      CCR1_L:
+        name: CCR1L
+    _merge:
+      - "CCR1*"
+    CCR1: [0, 4294967295]
+  CCR2:
+    _modify:
+      CCR2_H:
+        name: CCR2H
+        description: "Capture/Compare 2 value"
+      CCR2_L:
+        name: CCR2L
+    _merge:
+      - "CCR2*"
+    CCR2: [0, 4294967295]
+  CCR3:
+    _modify:
+      CCR3_H:
+        name: CCR3H
+        description: "Capture/Compare 3 value"
+      CCR3_L:
+        name: CCR3L
+    _merge:
+      - "CCR3*"
+    CCR3: [0, 4294967295]
+  CCR4:
+    _modify:
+      CCR4_H:
+        name: CCR4H
+        description: "Capture/Compare 4 value"
+      CCR4_L:
+        name: CCR4L
+    _merge:
+      - "CCR4*"
+    CCR4: [0, 4294967295]

--- a/peripherals/tim/tim2_32bit.yaml
+++ b/peripherals/tim/tim2_32bit.yaml
@@ -1,12 +1,11 @@
 # TIM2 32bit peripheral
-# TIM3 16bit
 # TIM2 is present on all devices except stm32f410 and stm32f0x0.
 # TIM2 is 16bit on STM32F1 family.
 # TIM3 is present on all devices with TIM2 except STML4x3 family.
 # TIM3 is present on stm32f0x0.
 
 
-"TIM2":
+"TIM[23]":
   CNT:
     # Actualy a 32bit register
     _modify:

--- a/peripherals/tim/tim2_32bit.yaml
+++ b/peripherals/tim/tim2_32bit.yaml
@@ -1,0 +1,31 @@
+# TIM2 32bit peripheral
+# TIM3 16bit
+# TIM2 is present on all devices except stm32f410 and stm32f0x0.
+# TIM2 is 16bit on STM32F1 family.
+# TIM3 is present on all devices with TIM2 except STML4x3 family.
+# TIM3 is present on stm32f0x0.
+
+
+"TIM2":
+  CNT:
+    # Actualy a 32bit register
+    _modify:
+      CNT_H:
+        name: CNTH
+        description: Counter value
+      CNT_L:
+        name: CNTL
+    _merge:
+      - "CNT*"
+    CNT: [0, 4294967295]
+  ARR:
+    # Actualy a 32bit register
+    _modify:
+      ARR_H:
+        name: ARRH
+        #value: [0, 65536]
+      ARR_L: 
+        name: ARRL
+    _merge:
+      - "ARR*"
+    ARR: [0, 65536]

--- a/peripherals/tim/tim2_common.yaml
+++ b/peripherals/tim/tim2_common.yaml
@@ -1,0 +1,19 @@
+# Common base for 16bit and 32bit TIM2 peripheral
+
+"TIM[23]":
+  CR1:
+    CKD:
+      NotDivided: [0, "CK_INT not divided"]
+      DividedBy2: [1, "CK_INT divided by 2"]
+      DividedBy4: [2, "CK_INT divided by 4"]
+    CMS:
+      Edge: [0, "The counter counts up or down depending on th direction bit (DIR)"]
+      CenterDown: [1, "The counter counts up and down alternatively. Output compare interrupt flags are set only when the counter is counting down"]
+      CenterUp: [2, "The counter counts up and down alternatively. Output compare interrupt flags are set only when the counter is counting up"]
+      CenterBoth: [3, "The counter counts up and down alternatively. Output compare interrupt flags are set only when the counter is counting up or down"]
+    DIR:
+      Up: [0, "Counter used as upcounter"]
+      Down: [1, "Counter used as downcounter"]
+    OPM:
+      NotStopped: [0, "Counter is not stopped at update event"]
+      Stopped: [1, "Counter stops counting at the next update event"]

--- a/peripherals/tim/tim2_common.yaml
+++ b/peripherals/tim/tim2_common.yaml
@@ -31,5 +31,5 @@
       CompareOC3: [6, "OC3REF signal is used as trigger output"]
       CompareOC4: [7, "OC4REF signal is used as trigger output"]
     CCDS:
-      OnCCx: [0, "CCx DMA request sent when CCx event occurs"]
+      OnCompare: [0, "CCx DMA request sent when CCx event occurs"]
       OnUpdate: [1, "CCx DMA request sent when update event occurs"]

--- a/peripherals/tim/tim2_common.yaml
+++ b/peripherals/tim/tim2_common.yaml
@@ -7,7 +7,7 @@
       DividedBy2: [1, "CK_INT divided by 2"]
       DividedBy4: [2, "CK_INT divided by 4"]
     CMS:
-      Edge: [0, "The counter counts up or down depending on th direction bit (DIR)"]
+      Edge: [0, "The counter counts up or down depending on the direction bit (DIR)"]
       CenterDown: [1, "The counter counts up and down alternatively. Output compare interrupt flags are set only when the counter is counting down"]
       CenterUp: [2, "The counter counts up and down alternatively. Output compare interrupt flags are set only when the counter is counting up"]
       CenterBoth: [3, "The counter counts up and down alternatively. Output compare interrupt flags are set only when the counter is counting up or down"]

--- a/peripherals/tim/tim2_common.yaml
+++ b/peripherals/tim/tim2_common.yaml
@@ -17,3 +17,19 @@
     OPM:
       NotStopped: [0, "Counter is not stopped at update event"]
       Stopped: [1, "Counter stops counting at the next update event"]
+  CR2:
+    TI1S:
+      Normal: [0, "The TIMx_CH1 pin is connected to TI1 input"]
+      XOR: [1, "The TIMx_CH1, CH2, CH3 pins are connected to TI1 input"]
+    MMS:
+      Reset: [0, "The UG bit from the TIMx_EGR register is used as trigger output"]
+      Enable: [1, "The counter enable signal, CNT_EN, is used as trigger output"]
+      Update: [2, "The update event is selected as trigger output"]
+      ComparePulse: [3, "The trigger output send a positive pulse when the CC1IF flag it to be set, as soon as a capture or a compare match occurred"]
+      CompareOC1: [4, "OC1REF signal is used as trigger output"]
+      CompareOC2: [5, "OC2REF signal is used as trigger output"] 
+      CompareOC3: [6, "OC3REF signal is used as trigger output"]
+      CompareOC4: [7, "OC4REF signal is used as trigger output"]
+    CCDS:
+      OnCCx: [0, "CCx DMA request sent when CCx event occurs"]
+      OnUpdate: [1, "CCx DMA request sent when update event occurs"]

--- a/peripherals/tim/tim6.yaml
+++ b/peripherals/tim/tim6.yaml
@@ -1,0 +1,18 @@
+# TIM6 and TIM7
+# Present accross all STM32 except STM32F401, STM32F413 and STM32F411 devices.
+# STM32F410 has only TIM6
+
+"TIM6":
+  CR2:
+    MMS:
+      Reset: [0, "Use UG bit from TIMx_EGR register"]
+      Enable: [1, "Use CNT bit from TIMx_CEN register"]
+      Update: [2, "Use the update event"]
+  CNT:
+    CNT: [0, 65536]
+  ARR:
+    ARR: [0, 65536]
+  DIER:
+    UDE:
+      Disabled: [0, "Update DMA request disabled"]
+      Enabled: [1, "Update DMA request enabled"]

--- a/peripherals/tim/tim_basic.yaml
+++ b/peripherals/tim/tim_basic.yaml
@@ -26,6 +26,8 @@
   EGR:
     UG:
       Update: [1, "Re-initializes the timer counter and generates an update of the reigsters."]
+  PSC:
+    PSC: [0, 65536]
 
 # OPM is often missing on TIM10, TIM11, TIM13, TIM14.
 # Annoyingly it is not always missing - include tim_opm.yaml for those devices.


### PR DESCRIPTION
Describes some common fields on basic TIM.
Describes TIM16 peripheral (apply on TIM17).
Describes TIM6 peripheral (apply on TIM7).
Add TIM16 to all devices that has this hardware.
Add TIM6 to all devices that has this hardware.
Add basic_timer on the STM32F0 family.
Describes some fields of TIM2 peripheral.
Add 32bit TIM2 peripheral to all devices that has it (all except F1 and L1).
Add 16bit TIM2 peripheral to all devices that has it (F1 and L1 family).