### PR TITLE
Adding some smarts to 'make html'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 **/Cargo.lock
 .deps/
 */src/stm32*/
+html/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: patch svd2rust
 
-.PHONY: patch svd2rust form clean-rs clean-patch clean
+.PHONY: patch svd2rust form clean-rs clean-patch clean-html clean
 
 SHELL := /bin/bash
 
@@ -57,7 +57,7 @@ svd2rust: $(RUST_SRCS)
 form: $(FORM_SRCS)
 
 html/index.html: $(PATCHED_SVDS)
-	@mkdir html
+	@mkdir -p html
 	python3 scripts/makehtml.py html/ svd/stm32*.svd.patched
 
 html: html/index.html
@@ -69,7 +69,7 @@ clean-patch:
 	rm -f $(PATCHED_SVDS)
 
 clean-html:
-	rm -rf html/fg
+	rm -rf html
 
 clean: clean-rs clean-patch clean-html
 	rm -rf .deps

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,10 @@ clean-rs:
 clean-patch:
 	rm -f $(PATCHED_SVDS)
 
-clean: clean-rs clean-patch
+clean-html:
+	rm -rf html/fg
+
+clean: clean-rs clean-patch clean-html
 	rm -rf .deps
 
 # Generate dependencies for each device YAML

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 all: patch svd2rust
 
+.PHONY: patch svd2rust form clean-rs clean-patch clean
+
 SHELL := /bin/bash
 
 CRATES := stm32f0 stm32f1 stm32f2 stm32f3 stm32f4 stm32f7 stm32h7 \
@@ -55,6 +57,7 @@ svd2rust: $(RUST_SRCS)
 form: $(FORM_SRCS)
 
 html/index.html: $(PATCHED_SVDS)
+	@mkdir html
 	python3 scripts/makehtml.py html/ svd/stm32*.svd.patched
 
 html: html/index.html

--- a/scripts/makehtml.py
+++ b/scripts/makehtml.py
@@ -171,7 +171,7 @@ if __name__ == "__main__":
     parser.add_argument("htmldir", help="Path to write HTML files to")
     parser.add_argument("svdfiles", help="Path to patched SVD files", nargs="*")
     args = parser.parse_args()
-    devices = []
+    devices = {}
     with multiprocessing.Pool() as p:
          devices = p.map(process_svd, args.svdfiles)
          p.map(generate_if_newer, devices)

--- a/scripts/makehtml.py
+++ b/scripts/makehtml.py
@@ -17,6 +17,7 @@ env = Environment(loader=PackageLoader('makehtml', ''))
 
 
 def generate_index_page(devices):
+    print("Generating Index")
     template = env.get_template('makehtml.index.template.html')
     return template.render(devices=devices)
 
@@ -30,6 +31,7 @@ def short_access(accs):
 
 def parse_device(svdfile):
     tree = ET.parse(svdfile)
+    temp = os.stat(svdfile).st_mtime
     dname = tree.findtext('name')
     peripherals = {}
     device_fields_total = 0
@@ -143,28 +145,36 @@ def parse_device(svdfile):
         device_fields_documented += peripheral_fields_documented
     return {"name": dname, "peripherals": peripherals,
             "fields_total": device_fields_total,
-            "fields_documented": device_fields_documented}
+            "fields_documented": device_fields_documented,
+            "last-modified": temp}
 
 
 def process_svd(svdfile):
     print("Processing", svdfile)
     device = parse_device(svdfile)
-    page = generate_device_page(device)
-    pagename = "{}.html".format(device["name"])
-    with open(os.path.join(args.htmldir, pagename), "w") as f:
-        f.write(page)
     return device
+
+
+def generate_if_newer(device):
+    pagename = "{}.html".format(device["name"])
+    filename = os.path.join(args.htmldir, pagename)
+    isfile = os.path.isfile(filename)
+    if not isfile or os.stat(filename).st_mtime < device['last-modified']:
+        page = generate_device_page(device)
+        print("Generating", pagename)
+        with open(filename, "w") as f:
+            f.write(page)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("htmldir", help="Path to write HTML files to")
-    parser.add_argument("svdfiles", help="Path to patched SVD files",
-                        nargs="*")
+    parser.add_argument("svdfiles", help="Path to patched SVD files", nargs="*")
     args = parser.parse_args()
-    devices = {}
+    devices = []
     with multiprocessing.Pool() as p:
-        devices = p.map(process_svd, args.svdfiles)
+         devices = p.map(process_svd, args.svdfiles)
+         p.map(generate_if_newer, devices)
     devices = {d['name']: d for d in devices}
     index_page = generate_index_page(devices)
     with open(os.path.join(args.htmldir, "index.html"), "w") as f:


### PR DESCRIPTION
Makehtml.py now only generates the html if there is not an associated html file or if the svd is newer. This is because the 'make html' target is much faster than the svd2rust target and is good for quickly checking your work. Now you can do it faster. I also added in a few corrections to the Makefile, such as PHONY designation.