### PR TITLE
Documented RCC and EXTI for STM32L100

### DIFF
--- a/devices/common_patches/rcc_LSECSSC_LSECSSF.yaml
+++ b/devices/common_patches/rcc_LSECSSC_LSECSSF.yaml
@@ -1,0 +1,15 @@
+RCC:
+  CIR:
+    _add:
+      LSECSSC:
+        description: "LSE Clock security system interrupt clear"
+        bitOffset: 22
+        bitWidth: 1
+      LSECSSF:
+        description: "LSE Clock security system interrupt flag"
+        bitOffset: 6
+        bitWidth: 1
+      LSECSSIE:
+        description: "LSE clock security system interrupt enable"
+        bitOffset: 14
+        bitWidth: 1

--- a/devices/stm32l100.yaml
+++ b/devices/stm32l100.yaml
@@ -73,15 +73,24 @@ RCC:
         bitWidth: 1
 
 _include:
+<<<<<<< HEAD
  - ./common_patches/rename_TIM2_CCR3_CCR3.yaml
+=======
+ - common_patches/rcc_LSECSSC_LSECSSF.yaml
+ - common_patches/gpio_with_OSPEEDER.yaml
+>>>>>>> Patching l100
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/spi/spi_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
- - ../devices/common_patches/gpio_with_OSPEEDER.yaml
  - ../peripherals/gpio/gpio_v2.yaml
+<<<<<<< HEAD
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/iwdg/iwdg.yaml
+=======
+ - ../peripherals/exti/exti_v1.yaml
+ - ../peripherals/rcc/rcc_l1.yaml
+>>>>>>> Patching l100

--- a/devices/stm32l100.yaml
+++ b/devices/stm32l100.yaml
@@ -73,12 +73,9 @@ RCC:
         bitWidth: 1
 
 _include:
-<<<<<<< HEAD
  - ./common_patches/rename_TIM2_CCR3_CCR3.yaml
-=======
- - common_patches/rcc_LSECSSC_LSECSSF.yaml
- - common_patches/gpio_with_OSPEEDER.yaml
->>>>>>> Patching l100
+ - ./common_patches/rcc_LSECSSC_LSECSSF.yaml
+ - ./common_patches/gpio_with_OSPEEDER.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/crc/crc_basic.yaml
@@ -86,11 +83,8 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_v2.yaml
-<<<<<<< HEAD
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/iwdg/iwdg.yaml
-=======
  - ../peripherals/exti/exti_v1.yaml
  - ../peripherals/rcc/rcc_l1.yaml
->>>>>>> Patching l100

--- a/devices/stm32l100.yaml
+++ b/devices/stm32l100.yaml
@@ -26,6 +26,52 @@ EXTI:
   PR:
     _split: [PR]
 
+RCC:
+  CR:
+    _merge: ["RTCPRE*"]
+  AHBLPENR:
+    _add:
+      FSMCLPEN:
+        description: "FSMC clock enable during Sleep mode"
+        bitOffset: 30
+        bitWidth: 1
+      AESLPEN:
+        description: "AES clock enable during Sleep mode"
+        bitOffset: 27
+        bitWidth: 1
+  APB1LPENR:
+    _add:
+      UART5LPEN:
+        description: "USART 5 clock enable during Sleep mode"
+        bitOffset: 20
+        bitWidth: 1
+      UART4LPEN:
+        description: "USART 4 clock enable during Sleep mode"
+        bitOffset: 19
+        bitWidth: 1
+      SPI3LPEN:
+        description: "SPI 3 clock enable during Sleep mode"
+        bitOffset: 15
+        bitWidth: 1
+      TIM5LPEN:
+        description: "Timer 5 clock enable during Sleep mode"
+        bitOffset: 3
+        bitWidth: 1
+  CSR:
+    _add:
+      OBLRSTF:
+        description: "Options bytes loading reset flag"
+        bitOffset: 25
+        bitWidth: 1
+      LSECSSD:
+        description: "CSS on LSE failure Detection"
+        bitOffset: 12
+        bitWidth: 1
+      LSECSSON:
+        description: "CSS on LSE enable"
+        bitOffset: 11
+        bitWidth: 1
+
 _include:
  - ./common_patches/rename_TIM2_CCR3_CCR3.yaml
  - ../peripherals/dac/dac_wavegen.yaml

--- a/peripherals/exti/exti_v1.yaml
+++ b/peripherals/exti/exti_v1.yaml
@@ -2,11 +2,11 @@ EXTI:
   IMR:
     "MR*":
       Masked: [0, "Interrupt request line is masked"]
-      Unmasked: [1, "Interrupt request line is masked"]
+      Unmasked: [1, "Interrupt request line is unmasked"]
   EMR:
     "MR*":
       Masked: [0, "Interrupt request line is masked"]
-      Unmasked: [1, "Interrupt request line is masked"]
+      Unmasked: [1, "Interrupt request line is unmasked"]
   RTSR:
     "TR*":
       Disabled: [0, "Rising edge trigger is disabled"]

--- a/peripherals/exti/exti_v1.yaml
+++ b/peripherals/exti/exti_v1.yaml
@@ -1,0 +1,27 @@
+EXTI:
+  IMR:
+    "MR*":
+      Masked: [0, "Interrupt request line is masked"]
+      Unmasked: [1, "Interrupt request line is masked"]
+  EMR:
+    "MR*":
+      Masked: [0, "Interrupt request line is masked"]
+      Unmasked: [1, "Interrupt request line is masked"]
+  RTSR:
+    "TR*":
+      Disabled: [0, "Rising edge trigger is disabled"]
+      Enabled: [1, "Rising edge trigger is enabled"]
+  FTSR:
+    "TR*":
+      Disabled: [0, "Falling edge trigger is disabled"]
+      Enabled: [1, "Falling edge trigger is enabled"]
+  SWIER:
+    "SWIER*":
+      _write:
+        Request: [1, "Generates an interrupt request"]
+  PR:
+    "PR*":
+      _write:
+        Clear: [1, "Clears pending bit"]
+      _read:
+        Pending: [1, "Selected trigger request occured"]

--- a/peripherals/rcc/rcc_l1.yaml
+++ b/peripherals/rcc/rcc_l1.yaml
@@ -6,8 +6,8 @@ RCC:
       DIV8: [2, "HSE divided by 8"]
       DIV16: [3, "HSE divided by 16"]
     "*ON":
-      Disabled: [0, "The selected clock is disabled"]
-      Enabled: [1, "The selected clock is enabled"]
+      Disabled: [0, "Clock disabled"]
+      Enabled: [1, "Clock enabled"]
     PLLRDY:
       _read:
         Unlocked: [0, "PPL unlocked"]
@@ -17,8 +17,8 @@ RCC:
       Bypassed: [1, "HSE oscillator bypassed"]
     "*RDY":
       _read:
-        NotReadied: [0, "The selected oscillator is not stable"]
-        Readied: [1, "The selected oscillator is not stable"]
+        NotReady: [0, "Oscillator is not stable"]
+        Ready: [1, "Oscillator is stable"]
   CFGR:
     MCOPRE:
       DIV1: [0, "No division"]
@@ -33,12 +33,12 @@ RCC:
       MSI: [3, "MSI oscillator clock selected"]
       HSE: [4, "HSE oscillator clock selected"]
       PLL: [5, "PLL clock selected"]
-      LSI: [6, "LSI oscillat or clock selected"]
+      LSI: [6, "LSI oscillator clock selected"]
       LSE: [7, "LSE oscillator clock selected"]
     PLLDIV:
-      DIV2: [2, "PLLVCO / 2"]
-      DIV3: [3, "PLLVCO / 3"]
-      DIV4: [4, "PLLVCO / 4"]
+      DIV2: [1, "PLLVCO / 2"]
+      DIV3: [2, "PLLVCO / 3"]
+      DIV4: [3, "PLLVCO / 4"]
     PLLMUL:
       MUL3: [0, "LL clock entry x 3"]
       MUL4: [1, "LL clock entry x 4"]
@@ -72,29 +72,29 @@ RCC:
       _read:
         HSI: [0, "MSI oscillator used as system clock"]
         MSI: [1, "HSI oscillator used as system clock"]
-        HSE: [2, "oscillator used as system clock"]
+        HSE: [2, "HSE oscillator used as system clock"]
         PLL: [3, "PLL used as system clock"]
     SW:
       HSI: [0, "MSI oscillator used as system clock"]
       MSI: [1, "HSI oscillator used as system clock"]
-      HSE: [2, "oscillator used as system clock"]
+      HSE: [2, "HSE oscillator used as system clock"]
       PLL: [3, "PLL used as system clock"]
   CIR:
     CSSC:
       _write:
-        Cleared: [1, "Clear selected interrupt"]
+        Clear: [1, "Clear interrupt"]
     "*CSSC":
       _write:
-        Cleared: [1, "Clear selected interrupt"]
+        Clear: [1, "Clear interrupt"]
     "*RDYC":
       _write:
-        Cleared: [1, "Clear selected interrupt"]
+        Clear: [1, "Clear interrupt"]
     LSECSSIE:
       Disabled: [0, "LSE CSS interrupt disabled"]
       Enabled: [1, "LSE CSS interrupt enabled"]
     "*RDYIE":
-      Disabled: [0, "Disabling selected interrupt"]
-      Enabled: [1, "Enabling selected interrupt"]
+      Disabled: [0, "Interrupt disabled"]
+      Enabled: [1, "Interrupt enabled"]
     CSSF:
       _read:
         NotInterupted: [0, "No clock security interrupt caused by HSE clock failure"]
@@ -105,33 +105,33 @@ RCC:
         Failure: [1, "A failure is detected on the external 32 kHz oscillator"]
     "*RDYF":
       _read:
-        NotStable: [0, "Selected clock is not stable"]
-        Stable: [1, "Selected clock is stable"]
+        NotStable: [0, "Clock is not stable"]
+        Stable: [1, "Clock is stable"]
   AHBRSTR:
     "*RST":
       _write:
-        Reset: [1, "Reset the selected module"]
+        Reset: [1, "Reset the module"]
   "APB[12]RSTR":
     "*RST":
       _write:
-        Reset: [1, "Reset the selected module"]
+        Reset: [1, "Reset the module"]
   AHBENR:
     "*EN":
-      Disabled: [0, "The selected clock is disabled"]
-      Enabled: [1, "The selected clock is enabled"]
+      Disabled: [0, "Clock disabled"]
+      Enabled: [1, "Clock enabled"]
   "APB*ENR":
     "*EN":
-      Disabled: [0, "The selected clock is disabled"]
-      Enabled: [1, "The selected clock is enabled"]
+      Disabled: [0, "Clock disabled"]
+      Enabled: [1, "Clock enabled"]
   "AHBLPENR":
     "*EN":
-      Disabled: [0, "The selected clock is disabled"]
-      Enabled: [1, "The selected clock is enabled"]
+      Disabled: [0, "Clock disabled"]
+      Enabled: [1, "Clock enabled"]
   CSR:
     "*RSTF":
       _read:
-        NoRest: [0, "No reset has occured"]
-        Rest: [1, "A reset has occured"]
+        NoReset: [0, "No reset has occured"]
+        Reset: [1, "A reset has occured"]
     RMVF:
       _write:
         Clear: [1, "Clears the reset flag"]

--- a/peripherals/rcc/rcc_l1.yaml
+++ b/peripherals/rcc/rcc_l1.yaml
@@ -1,0 +1,140 @@
+RCC:
+  CR:
+    RTCPRE:
+      DIV2: [0, "HSE divided by 2"]
+      DIV4: [1, "HSE divided by 4"]
+      DIV8: [2, "HSE divided by 8"]
+      DIV16: [3, "HSE divided by 16"]
+    "*ON":
+      Disabled: [0, "The selected clock is disabled"]
+      Enabled: [1, "The selected clock is enabled"]
+    PLLRDY:
+      _read:
+        Unlocked: [0, "PPL unlocked"]
+        Locked: [1, "PPL locked"]
+    HSEBYP:
+      NotBypassed: [0, "HSE oscillator not bypassed"]
+      Bypassed: [1, "HSE oscillator bypassed"]
+    "*RDY":
+      _read:
+        NotReadied: [0, "The selected oscillator is not stable"]
+        Readied: [1, "The selected oscillator is not stable"]
+  CFGR:
+    MCOPRE:
+      DIV1: [0, "No division"]
+      DIV2: [1, "Division by 2"]
+      DIV4: [2, "Division by 4"]
+      DIV8: [3, "Division by 8"]
+      DIV16: [4, "Division by 16"]
+    MCOSEL:
+      NoClock: [0, "No clock"]
+      SYSCLK: [1, "SYSCLK clock selected"]
+      HSI: [2, "HSI oscillator clock selected"]
+      MSI: [3, "MSI oscillator clock selected"]
+      HSE: [4, "HSE oscillator clock selected"]
+      PLL: [5, "PLL clock selected"]
+      LSI: [6, "LSI oscillat or clock selected"]
+      LSE: [7, "LSE oscillator clock selected"]
+    PLLDIV:
+      DIV2: [2, "PLLVCO / 2"]
+      DIV3: [3, "PLLVCO / 3"]
+      DIV4: [4, "PLLVCO / 4"]
+    PLLMUL:
+      MUL3: [0, "LL clock entry x 3"]
+      MUL4: [1, "LL clock entry x 4"]
+      MUL6: [2, "LL clock entry x 6"]
+      MUL8: [3, "LL clock entry x 8"]
+      MUL12: [4, "LL clock entry x 12"]
+      MUL16: [5, "LL clock entry x 16"]
+      MUL24: [6, "LL clock entry x 24"]
+      MUL32: [7, "LL clock entry x 32"]
+      MUL48: [8, "LL clock entry x 48"]
+    PLLSRC:
+      HSI: [0, "HSI selected as PLL input clock"]
+      HSE: [1, "HSE selected as PLL input clock"]
+    "PPRE[12]":
+      DIV1: [0, "HCLK not divided"] #The only the most significant bit has to be 0
+      DIV2: [4, "HCLK divided by 2"]
+      DIV4: [5, "HCLK divided by 4"]
+      DIV8: [6, "HCLK divided by 8"]
+      DIV16: [7, "HCLK divided by 16"]
+    HPRE:
+      DIV1: [0, "system clock not divided"]
+      DIV2: [8, "system clock divided by 2"]
+      DIV4: [9, "system clock divided by 4"]
+      DIV8: [10, "system clock divided by 8"]
+      DIV16: [11, "system clock divided by 16"]
+      DIV64: [12, "system clock divided by 64"]
+      DIV128: [13, "system clock divided by 128"]
+      DIV256: [14, "system clock divided by 256"]
+      DIV512: [15, "system clock divided by 512"]
+    SWS:
+      _read:
+        HSI: [0, "MSI oscillator used as system clock"]
+        MSI: [1, "HSI oscillator used as system clock"]
+        HSE: [2, "oscillator used as system clock"]
+        PLL: [3, "PLL used as system clock"]
+    SW:
+      HSI: [0, "MSI oscillator used as system clock"]
+      MSI: [1, "HSI oscillator used as system clock"]
+      HSE: [2, "oscillator used as system clock"]
+      PLL: [3, "PLL used as system clock"]
+  CIR:
+    CSSC:
+      _write:
+        Cleared: [1, "Clear selected interrupt"]
+    "*CSSC":
+      _write:
+        Cleared: [1, "Clear selected interrupt"]
+    "*RDYC":
+      _write:
+        Cleared: [1, "Clear selected interrupt"]
+    LSECSSIE:
+      Disabled: [0, "LSE CSS interrupt disabled"]
+      Enabled: [1, "LSE CSS interrupt enabled"]
+    "*RDYIE":
+      Disabled: [0, "Disabling selected interrupt"]
+      Enabled: [1, "Enabling selected interrupt"]
+    CSSF:
+      _read:
+        NotInterupted: [0, "No clock security interrupt caused by HSE clock failure"]
+        Interupted: [1, "Clock security interrupt caused by HSE clock failure"]
+    LSECSSF:
+      _read:
+        NoFailure: [0, "No failure detected on the external 32 KHz oscillator"]
+        Failure: [1, "A failure is detected on the external 32 kHz oscillator"]
+    "*RDYF":
+      _read:
+        NotStable: [0, "Selected clock is not stable"]
+        Stable: [1, "Selected clock is stable"]
+  AHBRSTR:
+    "*RST":
+      _write:
+        Reset: [1, "Reset the selected module"]
+  "APB[12]RSTR":
+    "*RST":
+      _write:
+        Reset: [1, "Reset the selected module"]
+  AHBENR:
+    "*EN":
+      Disabled: [0, "The selected clock is disabled"]
+      Enabled: [1, "The selected clock is enabled"]
+  "APB*ENR":
+    "*EN":
+      Disabled: [0, "The selected clock is disabled"]
+      Enabled: [1, "The selected clock is enabled"]
+  "AHBLPENR":
+    "*EN":
+      Disabled: [0, "The selected clock is disabled"]
+      Enabled: [1, "The selected clock is enabled"]
+  CSR:
+    "*RSTF":
+      _read:
+        NoRest: [0, "No reset has occured"]
+        Rest: [1, "A reset has occured"]
+    RMVF:
+      _write:
+        Clear: [1, "Clears the reset flag"]
+    RTCRST:
+      _write:
+        Reset: [1, "Resets the RTC peripheral"]


### PR DESCRIPTION
Adding documentation. Note this relies on pull request #60. It is presented as two separate pull request for simplicity. This serves to fully document the RCC and EXTI peripherals for the STM32L100. The only register that was not documented was the trimming register because I do not think I understand the documentation. 