### PR TITLE
Documents IWDG peripheral across all STM32 families

### DIFF
--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -10,7 +10,7 @@ _include:
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
- - ../peripherals/iwdg/iwdg.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/rcc/rcc_f0.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -18,7 +18,7 @@ _include:
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
- - ../peripherals/iwdg/iwdg.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -11,7 +11,7 @@ _include:
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
- - ../peripherals/iwdg/iwdg.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -11,7 +11,7 @@ _include:
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
- - ../peripherals/iwdg/iwdg.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f100.yaml
+++ b/devices/stm32f100.yaml
@@ -18,3 +18,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/dma/dma_v1.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f101.yaml
+++ b/devices/stm32f101.yaml
@@ -38,3 +38,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/dma/dma_v1.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f102.yaml
+++ b/devices/stm32f102.yaml
@@ -29,3 +29,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/dma/dma_v1.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f103.yaml
+++ b/devices/stm32f103.yaml
@@ -37,3 +37,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/dma/dma_v1.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f107.yaml
+++ b/devices/stm32f107.yaml
@@ -38,3 +38,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/dma/dma_v1.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f215.yaml
+++ b/devices/stm32f215.yaml
@@ -32,3 +32,4 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f217.yaml
+++ b/devices/stm32f217.yaml
@@ -32,3 +32,4 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -32,3 +32,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -20,3 +20,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -20,3 +20,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -9,3 +9,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -11,3 +11,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -10,3 +10,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f401.yaml
+++ b/devices/stm32f401.yaml
@@ -30,3 +30,4 @@ _include:
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -75,3 +75,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -110,3 +110,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f410.yaml
+++ b/devices/stm32f410.yaml
@@ -35,3 +35,4 @@ _include:
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f411.yaml
+++ b/devices/stm32f411.yaml
@@ -30,3 +30,4 @@ _include:
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -48,3 +48,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -42,3 +42,4 @@ _include:
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -74,3 +74,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -74,3 +74,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -56,3 +56,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -62,3 +62,4 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -22,3 +22,4 @@ _include:
  - ../peripherals/flash/flash_v2.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -32,3 +32,4 @@ _include:
  - ../peripherals/flash/flash_v2.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f7x5.yaml
+++ b/devices/stm32f7x5.yaml
@@ -147,3 +147,4 @@ _include:
  - ../peripherals/flash/flash_v2.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -130,3 +130,4 @@ _include:
  - ../peripherals/flash/flash_v2.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -295,3 +295,4 @@ _include:
  - ../peripherals/flash/flash_v2.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -282,3 +282,4 @@ _include:
  - ../peripherals/flash/flash_v2.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -239,6 +239,20 @@ _modify:
       AFSEL15:
         name: AFR15
 
+# Make IWDG register consitant
+IWDG:
+  _modify:
+    IWDG_KR:
+      name: KR
+    IWDG_PR:
+      name: PR
+    IWDG_RLR:
+      name: RLR
+    IWDG_SR:
+      name: SR
+    IWDG_WINR:
+      name: WINR
+
 # Merge the hundreds of individual bit fields into single fields for the
 # crypt key/iv registers.
 CRYP:
@@ -262,3 +276,4 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -7,3 +7,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1_with_remapping.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -8,3 +8,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1_with_remapping.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -8,3 +8,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1_with_remapping.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32l100.yaml
+++ b/devices/stm32l100.yaml
@@ -38,3 +38,4 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32l151.yaml
+++ b/devices/stm32l151.yaml
@@ -23,3 +23,4 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32l162.yaml
+++ b/devices/stm32l162.yaml
@@ -23,3 +23,4 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
+ - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -29,3 +29,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1_with_remapping.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -29,3 +29,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1_with_remapping.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -21,3 +21,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1_with_remapping.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -21,3 +21,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1_with_remapping.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -22,3 +22,4 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1_with_remapping.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/peripherals/iwdg/iwdg.yaml
+++ b/peripherals/iwdg/iwdg.yaml
@@ -1,5 +1,6 @@
-# IWDG peripheral.
-# Documented from stm32f0x1 reference manual
+# IWDG peripheral
+# Present on F1, F2, F4 and L1 families.
+# Base for `iwdg_with_window.yaml`.
 
 IWDG:
   KR:
@@ -19,5 +20,3 @@ IWDG:
       DivideBy256bis: [7, "Divider /256"]
   RLR:
     RL: [0, 4095]
-  WINR:
-    WIN: [0, 4095]

--- a/peripherals/iwdg/iwdg_with_WINR.yaml
+++ b/peripherals/iwdg/iwdg_with_WINR.yaml
@@ -1,0 +1,10 @@
+# IWDG peripheral with window register
+# Present on F0, F3, F7, L0 and L4 families.
+# Extend `iwdg.yaml`.
+
+_include:
+  - ./iwdg.yaml
+
+IWDG:
+  WINR:
+    WIN: [0, 4095]


### PR DESCRIPTION
I had to rename registers on `stm32fhx3` to match. Complete and generalize the previous IWDG PR.