### PR TITLE
Align Ethernet peripheral patches for the whole F4 family

### DIFF
--- a/devices/common_patches/f4_ethernet.yaml
+++ b/devices/common_patches/f4_ethernet.yaml
@@ -1,0 +1,34 @@
+Ethernet_MAC:
+  MACFFR:
+    _modify:
+      # This field should be 2 bits wide but is only 1 bit in the SVD
+      PCF:
+        bitWidth: 2
+  # All these fields are named incorrectly in the SVD compared to RM0090
+  MACA1LR:
+    _modify:
+      MACA1LR:
+        name: MACA1L
+  MACA2HR:
+    _modify:
+      MAC2AH:
+        name: MACA2H
+  MACA2LR:
+    _modify:
+      MACA2L:
+        bitWidth: 32
+  MACA3LR:
+    _modify:
+      MBCA3L:
+        name: MACA3L
+  MACMIIDR:
+    _modify:
+      TD:
+        name: MD
+
+Ethernet_DMA:
+  DMABMR:
+    _modify:
+      # This field is named incorrectly in the SVD compared to the RM
+      RTPR:
+        name: PM

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -23,37 +23,6 @@ _modify:
         bitWidth: 1
         access: read-write
 
-Ethernet_MAC:
-  MACFFR:
-    _modify:
-      # This field should be 2 bits wide but is only 1 bit in the SVD
-      PCF:
-        bitWidth: 2
-  # All these fields are named incorrectly in the SVD compared to RM0090
-  MACA1LR:
-    _modify:
-      MACA1LR:
-        name: MACA1L
-  MACA2HR:
-    _modify:
-      MAC2AH:
-        name: MACA2H
-  MACA2LR:
-    _modify:
-      MACA2L:
-        bitWidth: 32
-  MACA3LR:
-    _modify:
-      MBCA3L:
-        name: MACA3L
-
-Ethernet_DMA:
-  DMABMR:
-    _modify:
-      # This field is named incorrectly in the SVD compared to the RM
-      RTPR:
-        name: PM
-
 # Merge the thousands of individal bit fields into a single field for each
 # CAN filter register. This is not only much easier to use but also saves
 # a huge amount of filespace and compilation time etc -- as much as 30% of all
@@ -88,6 +57,7 @@ _include:
  - common_patches/merge_I2C_OAR1_ADDx_fields.yaml
  - common_patches/dma_fcr_wo.yaml
  - common_patches/ethernet_macmiidr.yaml
+ - common_patches/f4_ethernet.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -57,6 +57,7 @@ _include:
  - common_patches/merge_I2C_OAR1_ADDx_fields.yaml
  - common_patches/dma_fcr_wo.yaml
  - common_patches/ethernet_macmiidr.yaml
+ - common_patches/f4_ethernet.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml
@@ -69,6 +70,9 @@ _include:
  - ../peripherals/spi/spi_v1.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim_gp1.yaml
+ - ../peripherals/eth/eth_mac.yaml
+ - ../peripherals/eth/eth_mmc.yaml
+ - ../peripherals/eth/eth_dma.yaml
  - ../peripherals/usart/uart_common.yaml
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_usart.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -57,6 +57,7 @@ _include:
  - common_patches/merge_I2C_OAR1_ADDx_fields.yaml
  - common_patches/dma_fcr_wo.yaml
  - common_patches/ethernet_macmiidr.yaml
+ - common_patches/f4_ethernet.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml
@@ -69,6 +70,9 @@ _include:
  - ../peripherals/spi/spi_v1.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim_gp1.yaml
+ - ../peripherals/eth/eth_mac.yaml
+ - ../peripherals/eth/eth_mmc.yaml
+ - ../peripherals/eth/eth_dma.yaml
  - ../peripherals/usart/uart_common.yaml
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_usart.yaml

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -47,6 +47,7 @@ _include:
  - common_patches/merge_I2C_OAR1_ADDx_fields.yaml
  - common_patches/dma_fcr_wo.yaml
  - common_patches/ethernet_macmiidr.yaml
+ - common_patches/f4_ethernet.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml
@@ -57,6 +58,9 @@ _include:
  - ../peripherals/spi/spi_v1.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim_gp1.yaml
+ - ../peripherals/eth/eth_mac.yaml
+ - ../peripherals/eth/eth_mmc.yaml
+ - ../peripherals/eth/eth_dma.yaml
  - ../peripherals/usart/uart_common.yaml
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_usart.yaml


### PR DESCRIPTION
Except for STM32F469/479 all Ethernet peripeherals are described as
identical in RM0090 so this change makes sure that all existing patches
for the F407 are applied to the rest of the family as well for
consistency.

Fixes #70.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>