### PR TITLE
Documents some USART and LPUART

### DIFF
--- a/devices/common_patches/merge_LPUART_CR1_DEATx_fields.yaml
+++ b/devices/common_patches/merge_LPUART_CR1_DEATx_fields.yaml
@@ -1,0 +1,6 @@
+# Merge LPUART CR1 DEATx fields
+
+"LPUART*":
+  CR1:
+    _merge:
+      - "DEAT*"

--- a/devices/common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
+++ b/devices/common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
@@ -1,0 +1,6 @@
+# Merge LPUART CR1 DEDTx fields
+
+"LPUART*":
+  CR1:
+    _merge:
+      - "DEDT*"

--- a/devices/common_patches/merge_LPUART_CR2_ADDx_fields.yaml
+++ b/devices/common_patches/merge_LPUART_CR2_ADDx_fields.yaml
@@ -1,0 +1,11 @@
+# Merge LPUART CR2 ADDx fields
+
+"LPUART*":
+  CR2:
+    _modify:
+      "ADD0_3":
+        name: ADD0
+      "ADD4_7":
+        name: ADD4
+    _merge:
+      - "ADD[04]"

--- a/devices/common_patches/merge_USART_BRR_fields.yaml
+++ b/devices/common_patches/merge_USART_BRR_fields.yaml
@@ -1,0 +1,14 @@
+# Merge BRR fields together
+"USART*":
+  BRR:
+    _modify:
+      BRR_0_3:
+        name: BRR0
+      BRR_4_15:
+        name: BRR1
+      DIV_Mantissa:
+        name: BRR0
+      DIV_Fraction:
+        name: BRR1
+    _merge:
+      - "BRR*"

--- a/devices/common_patches/merge_USART_CR2_ADDx_fields.yaml
+++ b/devices/common_patches/merge_USART_CR2_ADDx_fields.yaml
@@ -1,0 +1,11 @@
+# Merge USART CR2 ADDx fields
+
+"USART*":
+  CR2:
+    _modify:
+      "ADD0_3":
+        name: ADD0
+      "ADD4_7":
+        name: ADD4
+    _merge:
+      - "ADD[04]"

--- a/devices/common_patches/rename_LPUART_CR2_DATAINV_field.yaml
+++ b/devices/common_patches/rename_LPUART_CR2_DATAINV_field.yaml
@@ -1,0 +1,8 @@
+# Rename LPUART CR2 DATAINV field
+# Other families has it.
+
+"LPUART*":
+  CR2:
+    _modify:
+      TAINV:
+        name: DATAINV

--- a/devices/common_patches/rename_USART_CR1_M0_field.yaml
+++ b/devices/common_patches/rename_USART_CR1_M0_field.yaml
@@ -1,0 +1,7 @@
+# Rename USART CR1 M to M0
+
+"USART*":
+  CR1:
+    _modify:
+      M:
+        name: M0

--- a/devices/common_patches/rename_USART_CR2_DATAINV_field.yaml
+++ b/devices/common_patches/rename_USART_CR2_DATAINV_field.yaml
@@ -1,0 +1,8 @@
+# Rename USART CR2 DATAINV field
+# Other families has it.
+
+"USART*":
+  CR2:
+    _modify:
+      TAINV:
+        name: DATAINV

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -22,3 +22,4 @@ _include:
  - ../peripherals/rcc/rcc_f0.yaml
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -5,6 +5,7 @@ _include:
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -6,6 +6,7 @@ _include:
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
+ - ./common_patches/rename_USART_CR1_M0_field.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -7,6 +7,7 @@ _include:
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR1_M0_field.yaml
+ - common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -31,3 +31,4 @@ _include:
  - ../peripherals/rcc/rcc_f0.yaml
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -13,6 +13,7 @@ _include:
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
+ - ./common_patches/rename_USART_CR1_M0_field.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -12,6 +12,7 @@ _include:
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -14,6 +14,7 @@ _include:
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR1_M0_field.yaml
+ - common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -24,3 +24,4 @@ _include:
  - ../peripherals/rcc/rcc_f0.yaml
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -6,6 +6,7 @@ _include:
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
+ - ./common_patches/rename_USART_CR1_M0_field.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -5,6 +5,7 @@ _include:
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -7,6 +7,7 @@ _include:
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR1_M0_field.yaml
+ - common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -24,3 +24,4 @@ _include:
  - ../peripherals/rcc/rcc_f0.yaml
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -6,6 +6,7 @@ _include:
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
+ - ./common_patches/rename_USART_CR1_M0_field.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -5,6 +5,7 @@ _include:
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -7,6 +7,7 @@ _include:
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR1_M0_field.yaml
+ - common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -24,6 +24,7 @@ _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/spi/spi_common.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -38,3 +38,4 @@ _include:
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/usart_v2B.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -25,6 +25,7 @@ _include:
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/spi/spi_common.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -26,3 +26,4 @@ _include:
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/usart_v2B.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -12,6 +12,7 @@ _include:
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -11,6 +11,7 @@ _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -26,3 +26,4 @@ _include:
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/usart_v2B.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -12,6 +12,7 @@ _include:
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -11,6 +11,7 @@ _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -5,6 +5,7 @@ _include:
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -15,3 +15,4 @@ _include:
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/usart_v2B.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -4,6 +4,7 @@ _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -5,6 +5,7 @@ _include:
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -4,6 +4,7 @@ _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -17,3 +17,4 @@ _include:
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/usart_v2B.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -16,3 +16,4 @@ _include:
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/usart_v2B.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -4,6 +4,7 @@ _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -5,6 +5,7 @@ _include:
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -30,3 +30,4 @@ _include:
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2_without_wakeup.yaml
+ - ../peripherals/usart/usart_v2C.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -14,6 +14,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
+ - common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -13,6 +13,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
+ - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -10,6 +10,7 @@ _include:
  - common_patches/4_nvic_prio_bits.yaml
  - common_patches/dma_fcr_wo.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -10,6 +10,7 @@ _include:
  - common_patches/4_nvic_prio_bits.yaml
  - common_patches/dma_fcr_wo.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -40,3 +40,4 @@ _include:
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2_without_wakeup.yaml
+ - ../peripherals/usart/usart_v2C.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -24,6 +24,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
+ - common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -23,6 +23,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
+ - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -20,6 +20,7 @@ _include:
  - common_patches/4_nvic_prio_bits.yaml
  - common_patches/dma_fcr_wo.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -20,6 +20,7 @@ _include:
  - common_patches/4_nvic_prio_bits.yaml
  - common_patches/dma_fcr_wo.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml

--- a/devices/stm32f7x5.yaml
+++ b/devices/stm32f7x5.yaml
@@ -135,6 +135,7 @@ _include:
  - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
+ - common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x5.yaml
+++ b/devices/stm32f7x5.yaml
@@ -132,6 +132,7 @@ _include:
  - common_patches/ethernet_macmiidr.yaml
  - common_patches/merge_USART_CR1_DEATx_fields.yaml
  - common_patches/merge_USART_CR1_DEDTx_fields.yaml
+ - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x5.yaml
+++ b/devices/stm32f7x5.yaml
@@ -134,6 +134,7 @@ _include:
  - common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - common_patches/merge_USART_CR2_ADDx_fields.yaml
+ - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x5.yaml
+++ b/devices/stm32f7x5.yaml
@@ -156,3 +156,4 @@ _include:
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32f7x5.yaml
+++ b/devices/stm32f7x5.yaml
@@ -133,6 +133,7 @@ _include:
  - common_patches/merge_USART_CR1_DEATx_fields.yaml
  - common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
+ - common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -117,6 +117,7 @@ _include:
  - common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - common_patches/merge_USART_CR2_ADDx_fields.yaml
+ - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -118,6 +118,7 @@ _include:
  - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
+ - common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -116,6 +116,7 @@ _include:
  - common_patches/merge_USART_CR1_DEATx_fields.yaml
  - common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
+ - common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -115,6 +115,7 @@ _include:
  - common_patches/ethernet_macmiidr.yaml
  - common_patches/merge_USART_CR1_DEATx_fields.yaml
  - common_patches/merge_USART_CR1_DEDTx_fields.yaml
+ - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -139,3 +139,4 @@ _include:
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -304,3 +304,4 @@ _include:
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -280,6 +280,7 @@ _include:
  - common_patches/merge_USART_CR1_DEATx_fields.yaml
  - common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
+ - common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -282,6 +282,7 @@ _include:
  - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - common_patches/merge_USART_CR2_ADDx_fields.yaml
  - common_patches/rename_USART_CR2_DATAINV_field.yaml
+ - common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -279,6 +279,7 @@ _include:
  - common_patches/ethernet_macmiidr.yaml
  - common_patches/merge_USART_CR1_DEATx_fields.yaml
  - common_patches/merge_USART_CR1_DEDTx_fields.yaml
+ - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -281,6 +281,7 @@ _include:
  - common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - common_patches/merge_USART_CR2_ADDx_fields.yaml
+ - common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -270,6 +270,7 @@ _include:
  - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
+ - common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -269,6 +269,7 @@ _include:
  - common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - common_patches/merge_USART_CR2_ADDx_fields.yaml
+ - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -267,6 +267,7 @@ _include:
  - common_patches/ethernet_macmiidr.yaml
  - common_patches/merge_USART_CR1_DEATx_fields.yaml
  - common_patches/merge_USART_CR1_DEDTx_fields.yaml
+ - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -268,6 +268,7 @@ _include:
  - common_patches/merge_USART_CR1_DEATx_fields.yaml
  - common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
+ - common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -291,3 +291,4 @@ _include:
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -313,6 +313,7 @@ _include:
  - common_patches/merge_USART_CR1_DEATx_fields.yaml
  - common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
+ - common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/tim/tim16.yaml

--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -314,6 +314,7 @@ _include:
  - common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - common_patches/merge_USART_CR2_ADDx_fields.yaml
+ - common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/tim/tim16.yaml

--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -312,6 +312,7 @@ _include:
  - common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - common_patches/merge_USART_CR1_DEATx_fields.yaml
  - common_patches/merge_USART_CR1_DEDTx_fields.yaml
+ - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/tim/tim16.yaml

--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -315,6 +315,7 @@ _include:
  - common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - common_patches/merge_USART_CR2_ADDx_fields.yaml
  - common_patches/rename_USART_CR2_DATAINV_field.yaml
+ - common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/tim/tim16.yaml

--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -323,3 +323,4 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -8,6 +8,7 @@ _include:
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
+ - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -20,3 +20,4 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/lpuart_v2A.yaml
+ - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -10,6 +10,7 @@ _include:
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -7,6 +7,7 @@ _include:
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
+ - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -9,6 +9,7 @@ _include:
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
+ - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -2,6 +2,7 @@ _svd: ../svd/stm32l0x1.svd
 
 _include:
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -19,3 +19,4 @@ _include:
  - ../peripherals/dma/dma_v1_with_remapping.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/lpuart_v2A.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -5,6 +5,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
+ - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -6,6 +6,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -2,6 +2,7 @@ _svd: ../svd/stm32l0x1.svd
 
 _include:
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -8,6 +8,7 @@ _modify:
 _include:
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
+ - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -8,6 +8,7 @@ _modify:
 _include:
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -13,6 +13,7 @@ _include:
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
+ - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -11,6 +11,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -10,6 +10,7 @@ _include:
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
+ - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -14,6 +14,7 @@ _include:
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
+ - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -12,6 +12,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
+ - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -26,3 +26,4 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/lpuart_v2A.yaml
+ - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -15,6 +15,7 @@ _include:
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -25,3 +25,4 @@ _include:
  - ../peripherals/dma/dma_v1_with_remapping.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/lpuart_v2A.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -7,6 +7,7 @@ _modify:
 
 _include:
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ../peripherals/dac/dac_common_1ch.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -12,6 +12,7 @@ _include:
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
+ - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -13,6 +13,7 @@ _include:
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
+ - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -10,6 +10,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
+ - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -11,6 +11,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -14,6 +14,7 @@ _include:
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
+ - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -26,3 +26,4 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/lpuart_v2A.yaml
+ - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -15,6 +15,7 @@ _include:
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -25,3 +25,4 @@ _include:
  - ../peripherals/dma/dma_v1_with_remapping.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/lpuart_v2A.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -7,6 +7,7 @@ _modify:
 
 _include:
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -23,6 +23,7 @@ RCC:
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
+ - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -29,6 +29,7 @@ _include:
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
+ - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -42,3 +42,4 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/lpuart_v2A.yaml
+ - ../peripherals/usart/usart_v2B2.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -22,6 +22,7 @@ RCC:
 
 _include:
  - common_patches/4_nvic_prio_bits.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -26,6 +26,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -31,6 +31,7 @@ _include:
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -26,6 +26,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -22,6 +22,7 @@ RCC:
 
 _include:
  - common_patches/4_nvic_prio_bits.yaml
+ - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -41,3 +41,4 @@ _include:
  - ../peripherals/dma/dma_v1_with_remapping.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/lpuart_v2A.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -28,6 +28,7 @@ _include:
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
+ - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -23,6 +23,7 @@ RCC:
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -26,6 +26,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
+ - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -29,6 +29,7 @@ _include:
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
+ - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -42,3 +42,4 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/lpuart_v2A.yaml
+ - ../peripherals/usart/usart_v2B2.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -26,6 +26,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
+ - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -28,6 +28,7 @@ _include:
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
+ - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -26,6 +26,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
+ - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -31,6 +31,7 @@ _include:
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -23,6 +23,7 @@ RCC:
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -41,3 +41,4 @@ _include:
  - ../peripherals/dma/dma_v1_with_remapping.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/lpuart_v2A.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -20,6 +20,7 @@ _include:
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
+ - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -33,3 +33,4 @@ _include:
  - ../peripherals/dma/dma_v1_with_remapping.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/lpuart_v2A.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -14,6 +14,7 @@ _svd: ../svd/stm32l4x3.svd
 
 _include:
  - common_patches/4_nvic_prio_bits.yaml
+ - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -23,6 +23,7 @@ _include:
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -34,3 +34,4 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/lpuart_v2A.yaml
+ - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -14,6 +14,7 @@ _svd: ../svd/stm32l4x3.svd
 
 _include:
  - common_patches/4_nvic_prio_bits.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -18,6 +18,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -21,6 +21,7 @@ _include:
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
+ - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -18,6 +18,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -18,6 +18,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -20,6 +20,7 @@ _include:
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
+ - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -33,3 +33,4 @@ _include:
  - ../peripherals/dma/dma_v1_with_remapping.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/lpuart_v2A.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -23,6 +23,7 @@ _include:
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -34,3 +34,4 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/lpuart_v2A.yaml
+ - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -14,6 +14,7 @@ _svd: ../svd/stm32l4x5.svd
 
 _include:
  - common_patches/4_nvic_prio_bits.yaml
+ - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -18,6 +18,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -21,6 +21,7 @@ _include:
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
+ - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -14,6 +14,7 @@ _svd: ../svd/stm32l4x5.svd
 
 _include:
  - common_patches/4_nvic_prio_bits.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -18,6 +18,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -18,6 +18,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -20,6 +20,7 @@ _include:
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
+ - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -21,6 +21,7 @@ _include:
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
+ - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -35,3 +35,4 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/lpuart_v2A.yaml
+ - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -14,6 +14,7 @@ _svd: ../svd/stm32l4x6.svd
 
 _include:
  - common_patches/4_nvic_prio_bits.yaml
+ - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -18,6 +18,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -14,6 +14,7 @@ _svd: ../svd/stm32l4x6.svd
 
 _include:
  - common_patches/4_nvic_prio_bits.yaml
+ - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -18,6 +18,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -18,6 +18,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
+ - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -23,6 +23,7 @@ _include:
  - ./common_patches/merge_LPUART_CR1_DEDTx_fields.yaml
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -34,3 +34,4 @@ _include:
  - ../peripherals/dma/dma_v1_with_remapping.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/usart/lpuart_v2A.yaml

--- a/peripherals/usart/_v2_ABC_common.yaml
+++ b/peripherals/usart/_v2_ABC_common.yaml
@@ -126,3 +126,20 @@ ISR:
   NF:
   FE:
   PE:
+ICR:
+  CMCF:
+    Clear: [1, "Clears the CMF flag in the ISR register"]
+  CTSCF:
+    Clear: [1, "Clears the CTSIF flag in the ISR register"]
+  TCCF:
+    Clear: [1, "Clears the TC flag in the ISR register"]
+  IDLECF:
+    Clear: [1, "Clears the IDLE flag in the ISR register"]
+  ORECF:
+    Clear: [1, "Clears the ORE flag in the ISR register"]
+  NCF:
+    Clear: [1, "Clears the NF flag in the ISR register"]
+  FECF:
+    Clear: [1, "Clears the FE flag in the ISR register"]
+  PECF:
+    Clear: [1, "Clears the PE flag in the ISR register"]

--- a/peripherals/usart/_v2_ABC_common.yaml
+++ b/peripherals/usart/_v2_ABC_common.yaml
@@ -111,3 +111,18 @@ RQR:
     Mute: [1, "Puts the USART in mute mode and sets the RWU flag"]
   SBKRQ:
     Break: [1, "sets the SBKF flag and request to send a BREAK on the line, as soon as the transmit machine is available"]
+ISR:
+  TEACK:
+  SBKF:
+  CMF:
+  BUSY:
+  CTS:
+  CTSIF:
+  TXE:
+  TC:
+  RXNE:
+  IDLE:
+  ORE:
+  NF:
+  FE:
+  PE:

--- a/peripherals/usart/_v2_ABC_common.yaml
+++ b/peripherals/usart/_v2_ABC_common.yaml
@@ -104,3 +104,10 @@ CR3:
   EIE:
     Disabled: [0, "Interrupt is inhibited"]
     Enabled: [1, "An interrupt is generated when FE=1 or ORE=1 or NF=1 in the ISR register"]
+RQR:
+  RXFRQ:
+    Discard: [1, "clears the RXNE flag. This allows to discard the received data without reading it, and avoid an overrun condition"]
+  MMRQ:
+    Mute: [1, "Puts the USART in mute mode and sets the RWU flag"]
+  SBKRQ:
+    Break: [1, "sets the SBKF flag and request to send a BREAK on the line, as soon as the transmit machine is available"]

--- a/peripherals/usart/_v2_ABC_common.yaml
+++ b/peripherals/usart/_v2_ABC_common.yaml
@@ -42,3 +42,31 @@ CR1:
   UE:
     Disabled: [0, "UART is disabled"]
     Enabled: [1, "UART is enabled"]
+CR2:
+  ADD: [0, 0xFF]
+  MSBFIRST:
+    LSB: [0, "data is transmitted/received with data bit 0 first, following the start bit"]
+    MSB: [1, "data is transmitted/received with MSB (bit 7/8/9) first, following the start bit"]
+  TXINV:
+    Standard: [0, "TX pin signal works using the standard logic levels"]
+    Inverted: [1, "TX pin signal values are inverted"]
+  RXINV:
+    Standard: [0, "RX pin signal works using the standard logic levels"]
+    Inverted: [1, "RX pin signal values are inverted"]
+  DATAINV:
+    Positive: [0, "Logical data from the data register are send/received in positive/direct logic"]
+    Negative: [1, "Logical data from the data register are send/received in negative/inverse logic"]
+  SWAP:
+    Standard: [0, "TX/RX pins are used as defined in standard pinout"]
+    Swapped: [1, "The TX and RX pins functions are swapped"]
+  STOP:
+    Bit_1: [0, "1 stop bit"]
+    Bit_0_5: [1, "0.5 stop bit"]
+    Bit_2: [2, "2 stop bit"]
+    Bit_1_5: [3, "1.5 stop bit"]
+  CLKEN:
+    Disabled: [0, "CK pin disabled"]
+    Enabled: [1, "CK pin enabled"]
+  ADDM7:
+    Bit_4: [0, "4-bit address detection"]
+    Bit_7: [1, "7-bit address detection"]

--- a/peripherals/usart/_v2_ABC_common.yaml
+++ b/peripherals/usart/_v2_ABC_common.yaml
@@ -143,3 +143,5 @@ ICR:
     Clear: [1, "Clears the FE flag in the ISR register"]
   PECF:
     Clear: [1, "Clears the PE flag in the ISR register"]
+RDR:
+  RDR: [0, 0xFF]

--- a/peripherals/usart/_v2_ABC_common.yaml
+++ b/peripherals/usart/_v2_ABC_common.yaml
@@ -70,3 +70,37 @@ CR2:
   ADDM7:
     Bit_4: [0, "4-bit address detection"]
     Bit_7: [1, "7-bit address detection"]
+CR3:
+  DEP:
+    High: [0, "DE signal is active high"]
+    Low: [1, "DE signal is active low"]
+  DEM:
+    Disabled: [0, "DE function is disabled"]
+    Enabled: [1, "The DE signal is output on the RTS pin"]
+  DDRE:
+    NotDisabled: [0, "DMA is not disabled in case of reception error"]
+    Disabled: [1, "DMA is disabled following a reception error"]
+  OVRDIS:
+    Enabled: [0, "Overrun Error Flag, ORE, is set when received data is not read before receiving new data"]
+    Disabled: [1, "Overrun functionality is disabled. If new data is received while the RXNE flag is still set the ORE flag is not set and the new received data overwrites the previous content of the RDR register"]
+  CTSIE:
+    Disabled: [0, "Interrupt is inhibited"]
+    Enabled: [1, "An interrupt is generated whenever CTSIF=1 in the ISR register"]
+  CTSE:
+    Disabled: [0, "CTS hardware flow control disabled"]
+    Enabled: [1, "CTS mode enabled, data is only transmitted when the CTS input is asserted"]
+  RTSE:
+    Disabled: [0, "RTS hardware flow control disabled"]
+    Enabled: [1, "RTS output enabled, data is only requested when there is space in the receive buffer"]
+  DMAT:
+    Disabled: [0, "DMA mode is disabled for transmission"]
+    Enabled: [1, "DMA mode is enabled for transmission"]
+  DMAR:
+    Disabled: [0, "DMA mode is disabled for reception"]
+    Enabled: [1, "DMA mode is enabled for reception"]
+  HDSEL:
+    NotSelected: [0, "Half duplex mode is not selected"]
+    Selected: [1, "Half duplex mode is selected"]
+  EIE:
+    Disabled: [0, "Interrupt is inhibited"]
+    Enabled: [1, "An interrupt is generated when FE=1 or ORE=1 or NF=1 in the ISR register"]

--- a/peripherals/usart/_v2_ABC_common.yaml
+++ b/peripherals/usart/_v2_ABC_common.yaml
@@ -1,0 +1,44 @@
+# Common fields between v2 A, B and C peripherals
+
+CR1:
+  DEAT: [0, 0b11111]
+  DEDT: [0, 0b11111]
+  CMIE:
+    Disabled: [0, "Interrupt is disabled"]
+    Enabled: [1, "Interrupt is generated when the CMF bit is set in the ISR register"]
+  MME:
+    Disabled: [0, "Receiver in active mode permanently"]
+    Enabled: [1, "Receiver can switch between mute mode and active mode"]
+  WAKE:
+    Idle: [0, "Idle line"]
+    Address: [1, "Address mask"]
+  PCE:
+    Disabled: [0, "Parity control disabled"]
+    Enabled: [1, "Parity control enabled"]
+  PS:
+    Even: [0, "Even parity"]
+    Odd: [1, "Odd parity"]
+  PEIE:
+    Disabled: [0, "Interrupt is disabled"]
+    Enabled: [1, "Interrupt is generated whenever PE=1 in the ISR register"]
+  TXEIE:
+    Disabled: [0, "Interrupt is disabled"]
+    Enabled: [1, "Interrupt is generated whenever TXE=1 in the ISR register"]
+  TCIE:
+    Disabled: [0, "Interrupt is disabled"]
+    Enabled: [1, "Interrupt is generated whenever TC=1 in the ISR register"]
+  RXNEIE:
+    Disabled: [0, "Interrupt is disabled"]
+    Enabled: [1, "Interrupt is generated whenever ORE=1 or RXNE=1 in the ISR register"]
+  IDLEIE:
+    Disabled: [0, "Interrupt is disabled"]
+    Enabled: [1, "Interrupt is generated whenever IDLE=1 in the ISR register"]
+  TE:
+    Disabled: [0, "Transmitter is disabled"]
+    Enabled: [1, "Transmitter is enabled"]
+  RE:
+    Disabled: [0, "Receiver is disabled"]
+    Enabled: [1, "Receiver is enabled"]
+  UE:
+    Disabled: [0, "UART is disabled"]
+    Enabled: [1, "UART is enabled"]

--- a/peripherals/usart/_v2_ABC_common.yaml
+++ b/peripherals/usart/_v2_ABC_common.yaml
@@ -145,3 +145,5 @@ ICR:
     Clear: [1, "Clears the PE flag in the ISR register"]
 RDR:
   RDR: [0, 0xFF]
+TDR:
+  TDR: [0, 0xFF]

--- a/peripherals/usart/_v2_AB_common.yaml
+++ b/peripherals/usart/_v2_AB_common.yaml
@@ -1,0 +1,6 @@
+# Common fields between v2 A and B peripherals
+
+CR1:
+  UESM:
+    Disabled: [0, "USART not able to wake up the MCU from Stop mode"]
+    Enabled: [1, "USART able to wake up the MCU from Stop mode"]

--- a/peripherals/usart/_v2_AB_common.yaml
+++ b/peripherals/usart/_v2_AB_common.yaml
@@ -12,3 +12,7 @@ CR3:
     Address: [0, "WUF active on address match"]
     Start: [2, "WuF active on Start bit detection"]
     RXNE: [3, "WUF active on RXNE"]
+ISR:
+  REAK:
+  WUF:
+  RWU:

--- a/peripherals/usart/_v2_AB_common.yaml
+++ b/peripherals/usart/_v2_AB_common.yaml
@@ -16,3 +16,6 @@ ISR:
   REAK:
   WUF:
   RWU:
+ICR:
+  WUCF:
+    Clear: [1, "Clears the WUF flag in the ISR register"]

--- a/peripherals/usart/_v2_AB_common.yaml
+++ b/peripherals/usart/_v2_AB_common.yaml
@@ -4,3 +4,11 @@ CR1:
   UESM:
     Disabled: [0, "USART not able to wake up the MCU from Stop mode"]
     Enabled: [1, "USART able to wake up the MCU from Stop mode"]
+CR3:
+  WUFIE:
+    Disabled: [0, "Interrupt is inhibited"]
+    Enabled: [1, "An USART interrupt is generated whenever WUF=1 in the ISR register"]
+  WUS:
+    Address: [0, "WUF active on address match"]
+    Start: [2, "WuF active on Start bit detection"]
+    RXNE: [3, "WUF active on RXNE"]

--- a/peripherals/usart/_v2_BC_common.yaml
+++ b/peripherals/usart/_v2_BC_common.yaml
@@ -59,3 +59,6 @@ CR3:
     Enabled: [1, "IrDA enabled"]
 BRR:
   BRR: [0, 0xFFFF]
+GTPR:
+  GT: [0, 0xFF]
+  PSC: [0, 0xFF]

--- a/peripherals/usart/_v2_BC_common.yaml
+++ b/peripherals/usart/_v2_BC_common.yaml
@@ -1,0 +1,12 @@
+# Common fields between v2 B and C peripherals
+
+CR1:
+  OVER8:
+    Oversampling_16: [0, "Oversampling by 16"]
+    Oversampling_8: [1, "Oversampling by 8"]
+  EOBIE:
+    Disabled: [0, "Interrupt is inhibited"]
+    Enabled: [1, "A USART interrupt is generated when the EOBF flag is set in the ISR register"]
+  RTOIE:
+    Disabled: [0, "Interrupt is inhibited"]
+    Enabled: [1, "An USART interrupt is generated when the RTOF bit is set in the ISR register"]

--- a/peripherals/usart/_v2_BC_common.yaml
+++ b/peripherals/usart/_v2_BC_common.yaml
@@ -65,3 +65,8 @@ GTPR:
 RTOR:
   BLEN: [0, 0xFF]
   RTO: [0, 0xFFFFFF]
+RQR:
+  TXFRQ:
+    Discard: [1, "Set the TXE flags. This allows to discard the transmit data"]
+  ABRRQ:
+    Request: [1, "resets the ABRF flag in the USART_ISR and request an automatic baud rate measurement on the next received data frame"]

--- a/peripherals/usart/_v2_BC_common.yaml
+++ b/peripherals/usart/_v2_BC_common.yaml
@@ -10,3 +10,33 @@ CR1:
   RTOIE:
     Disabled: [0, "Interrupt is inhibited"]
     Enabled: [1, "An USART interrupt is generated when the RTOF bit is set in the ISR register"]
+CR2:
+  RTOEN:
+    Disabled: [0, "Receiver timeout feature disabled"]
+    Enabled: [1, "Receiver timeout feature enabled"]
+  ABRMOD:
+    Start: [0, "Measurement of the start bit is used to detect the baud rate"]
+    Edge: [1, "Falling edge to falling edge measurement"]
+    Frame_7F: [2, "0x7F frame detection"]
+    Frame_55: [3, "0x55 frame detection"]
+  ABREN:
+    Disabled: [0, "Auto baud rate detection is disabled"]
+    Enabled: [1, "Auto baud rate detection is enabled"]
+  LINEN:
+    Disabled: [0, "LIN mode disabled"]
+    Enabled: [1, "LIN mode enabled"]
+  CPOL:
+    Low: [0, "Steady low value on CK pin outside transmission window"]
+    High: [1, "Steady high value on CK pin outside transmission window"]
+  CPHA:
+    First: [0, "The first clock transition is the first data capture edge"]
+    Second: [1, "The second clock transition is the first data capture edge"]
+  LBCL:
+    NotOutput: [0, "The clock pulse of the last data bit is not output to the CK pin"]
+    Output: [1, "The clock pulse of the last data bit is output to the CK pin"]
+  LBDIE:
+    Disabled: [0, "Interrupt is inhibited"]
+    Enabled: [1, "An interrupt is generated whenever LBDF=1 in the ISR register"]
+  LBDL:
+    Bit_10: [0, "10-bit break detection"]
+    Bit_11: [1, "11-bit break detection"]

--- a/peripherals/usart/_v2_BC_common.yaml
+++ b/peripherals/usart/_v2_BC_common.yaml
@@ -70,3 +70,9 @@ RQR:
     Discard: [1, "Set the TXE flags. This allows to discard the transmit data"]
   ABRRQ:
     Request: [1, "resets the ABRF flag in the USART_ISR and request an automatic baud rate measurement on the next received data frame"]
+ISR:
+  ABRF:
+  ABRE:
+  EOBF:
+  RTOF:
+  LBDF:

--- a/peripherals/usart/_v2_BC_common.yaml
+++ b/peripherals/usart/_v2_BC_common.yaml
@@ -40,3 +40,20 @@ CR2:
   LBDL:
     Bit_10: [0, "10-bit break detection"]
     Bit_11: [1, "11-bit break detection"]
+CR3:
+  SCARCNT: [0, 7]
+  ONEBIT:
+    Sample_3: [0, "Three sample bit method"]
+    Sample_1: [1, "One sample bit method"]
+  SCEN:
+    Disabled: [0, "Smartcard Mode disabled"]
+    Enabled: [1, "Smartcard Mode enabled"]
+  NACK:
+    Disabled: [0, "NACK transmission in case of parity error is disabled"]
+    Enabled: [1, "NACK transmission during parity error is enabled"]
+  IRLP:
+    Normal: [0, "Normal mode"]
+    LowPower: [1, "Low-power mode"]
+  IREN:
+    Disabled: [0, "IrDA disabled"]
+    Enabled: [1, "IrDA enabled"]

--- a/peripherals/usart/_v2_BC_common.yaml
+++ b/peripherals/usart/_v2_BC_common.yaml
@@ -57,3 +57,5 @@ CR3:
   IREN:
     Disabled: [0, "IrDA disabled"]
     Enabled: [1, "IrDA enabled"]
+BRR:
+  BRR: [0, 0xFFFF]

--- a/peripherals/usart/_v2_BC_common.yaml
+++ b/peripherals/usart/_v2_BC_common.yaml
@@ -76,3 +76,10 @@ ISR:
   EOBF:
   RTOF:
   LBDF:
+ICR:
+  EOBCF:
+    Clear: [1, "Clears the EOBF flag in the ISR register"]
+  LBDCF:
+    Clear: [1, "Clears the LBDF flag in the ISR register"]
+  RTOCF:
+    Clear: [1, "Clears the RTOF flag in the ISR register"]

--- a/peripherals/usart/_v2_BC_common.yaml
+++ b/peripherals/usart/_v2_BC_common.yaml
@@ -62,3 +62,6 @@ BRR:
 GTPR:
   GT: [0, 0xFF]
   PSC: [0, 0xFF]
+RTOR:
+  BLEN: [0, 0xFF]
+  RTO: [0, 0xFFFFFF]

--- a/peripherals/usart/_v2_with_7bit_data.yaml
+++ b/peripherals/usart/_v2_with_7bit_data.yaml
@@ -1,0 +1,10 @@
+# USART v2 with 7bit data
+
+# FIXME workaround separated M0 and M1 fields
+CR1:
+  M0:
+    Bit_8: [0, "1 start bit, 8 data bits, n stop bits"]
+    Bit_9: [1, "1 start bit, 9 data bits, n stop bits"]
+  M1:
+    M0: [0, "Use M0 to set the data bits"]
+    Bit_7: [1, "1 start bit, 7 data bits, n stop bits"]

--- a/peripherals/usart/_v2_without_7bit_data.yaml
+++ b/peripherals/usart/_v2_without_7bit_data.yaml
@@ -1,0 +1,6 @@
+# USART v2 without 7bit data
+
+CR1:
+  M:
+    Bit_8: [0, "1 start bit, 8 data bits, n stop bits"]
+    Bit_9: [1, "1 start bit, 9 data bits, n stop bits"]

--- a/peripherals/usart/lpuart_v2A.yaml
+++ b/peripherals/usart/lpuart_v2A.yaml
@@ -1,0 +1,12 @@
+# LPUART1 found on L0 and L4 families
+
+LPUART1:
+  _include:
+    - _v2_ABC_common.yaml
+    - _v2_AB_common.yaml
+    - _v2_with_7bit_data.yaml
+
+  ISR:
+    CMCF:
+  BRR:
+    BRR: [0, 0xFFFFF]

--- a/peripherals/usart/usart_v2B.yaml
+++ b/peripherals/usart/usart_v2B.yaml
@@ -1,0 +1,8 @@
+# USART v2B found on F3 family
+
+"USART*":
+  _include:
+    - _v2_ABC_common.yaml
+    - _v2_AB_common.yaml
+    - _v2_BC_common.yaml
+    - _v2_without_7bit_data.yaml

--- a/peripherals/usart/usart_v2B1.yaml
+++ b/peripherals/usart/usart_v2B1.yaml
@@ -1,0 +1,10 @@
+# USART v2B1 found on F0, F7, L0 and L4 family
+# Same as USART v2B with 7bit data functionality
+
+"USART*":
+  _include:
+    - _v2_ABC_common.yaml
+    - _v2_AB_common.yaml
+    - _v2_BC_common.yaml
+    - _v2_with_7bit_data.yaml
+

--- a/peripherals/usart/usart_v2B2.yaml
+++ b/peripherals/usart/usart_v2B2.yaml
@@ -1,0 +1,20 @@
+# USART v2B2 found on some L4 devices
+# Same as USART v2B1 with more fields
+
+# Handle USART1 and USART3 common field
+_include:
+  - usart_v2B1.yaml
+
+# USART3 specific fields
+"USART3":
+  CR3:
+    TCBGTIE:
+      Disabled: [0, "Interrupt is inhibited"]
+      Enabled: [1, "An USART interrupt is generated whenever TCBGT=1 in the ISR register"]
+    UCESM:
+      Disabled: [0, "USART clock is disabled in STOP mode"]
+      Enabled: [1, "USART clock is enabled in STOP mode"]
+  ISR:
+    TCBGT:
+      NotCompleted: [0, "Transmission not completed"]
+      Completed: [1, "Transmission has completed"]

--- a/peripherals/usart/usart_v2C.yaml
+++ b/peripherals/usart/usart_v2C.yaml
@@ -1,0 +1,7 @@
+# USART v2C found on some F7 devices
+
+"USART*":
+  _include:
+    - _v2_ABC_common.yaml
+    - _v2_BC_common.yaml
+    - _v2_with_7bit_data.yaml


### PR DESCRIPTION
F0, F3, F7, H7, L0 and L4 families are covered.

I versioned  the peripherals with v2 to differentiate with other family (UART and USART) peripherals. I use arbitrary letter for subdividing the USART v2 peripherals tree.

The fields are documented but the svd get not patched, caused by #67 issue. So I can't checks if all fields are documented. I greatly appreciate If you can help me to find how to make include inside peripheral working. 