### PR TITLE
f0: replace JITOFF_D* by CKMODE in ADC CFGR2 to match RM0360 and RM0091

### DIFF
--- a/devices/common_patches/f0_adc_cfgr2_ckmode.yaml
+++ b/devices/common_patches/f0_adc_cfgr2_ckmode.yaml
@@ -1,0 +1,13 @@
+# Merge together ADC CFGR2 separated JITOFF_Dx fields
+# and properly rename to CKMODE
+
+"ADC":
+  CFGR2:
+    _modify:
+      JITOFF_D2:
+        name: CKMODE0
+      JITOFF_D4:
+        name: CKMODE1
+        description: "ADC clock mode"
+    _merge:
+      - "CKMODE*"

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -4,6 +4,7 @@ _include:
  - ./common_patches/rename_RCC_CIR_HSI14RDYIE_field.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
+ - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -11,6 +11,7 @@ _include:
  - ./common_patches/rename_RCC_CIR_HSI14RDYIE_field.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
+ - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -4,6 +4,7 @@ _include:
  - ./common_patches/rename_RCC_CIR_HSI14RDYIE_field.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
+ - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -4,6 +4,7 @@ _include:
  - ./common_patches/rename_RCC_CIR_HSI14RDYIE_field.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
+ - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml


### PR DESCRIPTION
This fixes misnamed fields in ADC CFGR2 for all stm32f0.
The fields JITOFF_D2 and JITOFF_D4 don't exist in the stm32l0 reference manual, which instead contains a CKMODE field.
This CKMODE field is the same as in stm32l0 (for which svd files are correct).