### PR TITLE
stm32f429: add missing RCC reset/enable bits

### DIFF
--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -52,6 +52,142 @@ FMC:
       addressOffset: "0x11C"
       alternateRegister: ""
 
+# Add missing bits to RCC_CR
+RCC:
+  CR:
+    _add:
+      PLLSAIRDY:
+        description: PLLSAI clock ready flag
+        bitOffset: 29
+        bitWidth: 1
+        access: read-only
+      PLLSAION:
+        description: PLLSAI enable
+        bitOffset: 28
+        bitWidth: 1
+        access: read-write
+
+# Add missing RCC enable and reset bits
+RCC:
+  AHB1RSTR:
+    _add:
+      DMA2DRST:
+        description: DMA2D reset
+        bitOffset: 23
+        bitWidth: 1
+  APB1RSTR:
+    _add:
+      UART7RST:
+        description: UART 7 reset
+        bitOffset: 30
+        bitWidth: 1
+      UART8RST:
+        description: UART 8 reset
+        bitOffset: 31
+        bitWidth: 1
+  APB2RSTR:
+    _add:
+      SPI4RST:
+        description: SPI 4 reset
+        bitOffset: 13
+        bitWidth: 1
+      SPI5RST:
+        description: SPI 5 reset
+        bitOffset: 20
+        bitWidth: 1
+      SPI6RST:
+        description: SPI 6 reset
+        bitOffset: 21
+        bitWidth: 1
+      SAI1RST:
+        description: SAI 1 reset
+        bitOffset: 22
+        bitWidth: 1
+      LTDCRST:
+        description: LTDC reset
+        bitOffset: 26
+        bitWidth: 1
+  AHB1ENR:
+    _add:
+      DMA2DEN:
+        description: DMA2D clock enable
+        bitOffset: 23
+        bitWidth: 1
+  APB1ENR:
+    _add:
+      UART7EN:
+        description: UART 7 clock enable
+        bitOffset: 30
+        bitWidth: 1
+      UART8EN:
+        description: UART 8 clock enable
+        bitOffset: 31
+        bitWidth: 1
+  APB2ENR:
+    _add:
+      SPI4EN:
+        description: SPI 4 clock enable
+        bitOffset: 13
+        bitWidth: 1
+      SPI5EN:
+        description: SPI 5 clock enable
+        bitOffset: 20
+        bitWidth: 1
+      SPI6EN:
+        description: SPI 6 clock enable
+        bitOffset: 21
+        bitWidth: 1
+      SAI1EN:
+        description: SAI 1 clock enable
+        bitOffset: 22
+        bitWidth: 1
+      LTDCEN:
+        description: LTDC clock enable
+        bitOffset: 26
+        bitWidth: 1
+  AHB1LPENR:
+    _add:
+      SRAM3LPEN:
+        description: SRAM 3 interface clock enable during Sleep mode
+        bitOffset: 19
+        bitWidth: 1
+      DMA2DLPEN:
+        description: DMA2D clock enable during Sleep mode
+        bitOffset: 23
+        bitWidth: 1
+  APB1LPENR:
+    _add:
+      UART7LPEN:
+        description: UART 7 clock enable during Sleep mode
+        bitOffset: 30
+        bitWidth: 1
+      UART8LPEN:
+        description: UART 8 clock enable during Sleep mode
+        bitOffset: 31
+        bitWidth: 1
+  APB2LPENR:
+    _add:
+      SPI4LPEN:
+        description: SPI 4 clock enable during Sleep mode
+        bitOffset: 13
+        bitWidth: 1
+      SPI5LPEN:
+        description: SPI 5 clock enable during Sleep mode
+        bitOffset: 20
+        bitWidth: 1
+      SPI6LPEN:
+        description: SPI 6 clock enable during Sleep mode
+        bitOffset: 21
+        bitWidth: 1
+      SAI1LPEN:
+        description: SAI 1 clock enable during Sleep mode
+        bitOffset: 22
+        bitWidth: 1
+      LTDCLPEN:
+        description: LTDC clock enable during Sleep mode
+        bitOffset: 26
+        bitWidth: 1
+
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - common_patches/merge_I2C_OAR1_ADDx_fields.yaml


### PR DESCRIPTION
This is ported from a similar PR I made to the `stm32f429` crate. Your version of patching SVDs is much nicer :)

The only things now missing compared to their SVD patch is:

* descriptions for the MAC registers - you already have descriptions for the individual bits though

I guess I can add these to the global MAC yaml?

* a DEVICE_ID peripheral to read out the three unique ID words at 0x1FFF7A10

Do you want to have this included? It's probably relevant to all STMs?