### PR TITLE
eth_mac: add field descriptions

### DIFF
--- a/peripherals/eth/eth_dma.yaml
+++ b/peripherals/eth/eth_dma.yaml
@@ -44,20 +44,57 @@
       RxPriority: [1, "Rx has priority over Tx"]
     SR:
       Reset: [1, "Reset all MAC subsystem internal registers and logic. Cleared automatically"]
+    _modify:
+      MB:
+        description: Mixed burst
+      AAB:
+        description: Address-aligned beats
+      FPM:
+        description: 4xPBL mode
+      USP:
+        description: Use separate PBL
+      RDP:
+        description: Rx DMA PBL
+      FB:
+        description: Fixed burst
+      PM:
+        description: Rx-Tx priority ratio
+      PBL:
+        description: Programmable burst length
+      EDFE:
+        description: Enhanced descriptor format enable
+      DSL:
+        description: Descriptor skip length
+      DA:
+        description: DMA arbitration
+      SR:
+        description: Software reset
 
   DMATPDR:
     TPD:
       Poll: [0, "Poll the transmit descriptor list"]
+    _modify:
+      TPD:
+        description: Transmit poll demand
 
   DMARPDR:
     RPD:
       Poll: [0, "Poll the receive descriptor list"]
+    _modify:
+      RPD:
+        description: Receive poll demand
 
   DMARDLAR:
     SRL: [0, 0xFFFFFFFF]
+    _modify:
+      SRL:
+        description: Start of receive list
 
   DMATDLAR:
     STL: [0, 0xFFFFFFFF]
+    _modify:
+      STL:
+        description: Start of transmit list
 
   DMASR:
     TPS:
@@ -73,6 +110,49 @@
       RunningWaiting: [3, "Running, waiting for receive packet"]
       Suspended: [4, "Suspended, receive descriptor unavailable"]
       RunningWriting: [7, "Running, writing data to host memory buffer"]
+    _modify:
+      TSTS:
+        description: Time stamp trigger status
+      PMTS:
+        description: PMT status
+      MMCS:
+        description: MMC status
+      EBS:
+        description: Error bits status
+      TPS:
+        description: Transmit process state
+      RPS:
+        description: Receive process state
+      NIS:
+        description: Normal interrupt summary
+      AIS:
+        description: Abnormal interrupt summary
+      ERS:
+        description: Early receive status
+      FBES:
+        description: Fatal bus error status
+      ETS:
+        description: Early transmit status
+      RWTS:
+        description: Receive watchdog timeout status
+      RPSS:
+        description: Receive process stopped status
+      RBUS:
+        description: Receive buffer unavailable status
+      RS:
+        description: Receive status
+      TUS:
+        description: Transmit underflow status
+      ROS:
+        description: Receive overflow status
+      TJTS:
+        description: Transmit jabber timeout status
+      TBUS:
+        description: Transmit buffer unavailable status
+      TPSS:
+        description: Transmit process stopped status
+      TS:
+        description: Transmit status
 
   DMAOMR:
     DTCEFD:
@@ -114,6 +194,98 @@
     SR:
       Stopped: [0, "Reception is stopped after transfer of the current frame"]
       Started: [1, "Reception is placed in the Running state"]
+    _modify:
+      DTCEFD:
+        description: Dropping of TCP/IP checksum error frames disable
+      RSF:
+        description: Receive store and forward
+      DFRF:
+        description: Disable flushing of received frames
+      TSF:
+        description: Transmit store and forward
+      FTF:
+        description: Flush transmit FIFO
+      TTC:
+        description: Transmit threshold control
+      ST:
+        description: Start/stop transmission
+      FEF:
+        description: Forward error frames
+      FUGF:
+        description: Forward undersized good frames
+      RTC:
+        description: Receive threshold control
+      OSF:
+        description: Operate on second frame
+      SR:
+        description: Start/stop receive
+
+  DMAIER:
+    _modify:
+      NISE:
+        description: Normal interrupt summary enable
+      AISE:
+        description: Abnormal interrupt summary enable
+      ERIE:
+        description: Early receive interrupt enable
+      FBEIE:
+        description: Fatal bus error interrupt enable
+      ETIE:
+        description: Early transmit interrupt enable
+      RWTIE:
+        description: Receive watchdog timeout interrupt enable
+      RPSIE:
+        description: Receive process stopped interrupt enable
+      RBUIE:
+        description: Receive buffer unavailable interrupt enable
+      RIE:
+        description: Receive interrupt enable
+      TUIE:
+        description: Transmit underflow interrupt enable
+      ROIE:
+        description: Receive overflow interrupt enable
+      TJTIE:
+        description: Transmit jabber timeout interrupt enable
+      TBUIE:
+        description: Transmit buffer unavailable interrupt enable
+      TPSIE:
+        description: Transmit process stopped interrupt enable
+      TIE:
+        description: Transmit interrupt enable
+
+  DMAMFBOCR:
+    _modify:
+      OFOC:
+        description: Overflow bit for FIFO overflow counter
+      MFA:
+        description: Missed frames by the application
+      OMFC:
+        description: Overflow bit for missed frame counter
+      MFC:
+        description: Missed frames by the controller
 
   DMARSWTR:
     RSWTC: [0, 0xFF]
+    _modify:
+      RSWTC:
+        description: Receive status watchdog timer count
+
+  DMACHTDR:
+    _modify:
+      HTDAP:
+        description: Host transmit descriptor address pointer
+
+  DMACHRDR:
+    _modify:
+      HRDAP:
+        description: Host receive descriptor address pointer
+
+  DMACHTBAR:
+    _modify:
+      HTBAP:
+        description: Host transmit buffer address pointer
+
+  DMACHRBAR:
+    _modify:
+      HRBAP:
+        description: Host receive buffer address pointer

--- a/peripherals/eth/eth_mac.yaml
+++ b/peripherals/eth/eth_mac.yaml
@@ -112,7 +112,7 @@
     BFD:
       Enabled: [0, "Address filters pass all received broadcast frames"]
       Disabled: [1, "Address filters filter all incoming broadcast frames"]
-    RAM:
+    PAM:
       Disabled: [0, "Filtering of multicast frames depends on HM"]
       Enabled: [1, "All received frames with a multicast destination address are passed"]
     DAIF:
@@ -141,6 +141,7 @@
       BFD:
         description: Broadcast frames disable
       RAM:
+        name: PAM
         description: Pass all multicast
       DAIF:
         description: Destination address unique filtering

--- a/peripherals/eth/eth_mac.yaml
+++ b/peripherals/eth/eth_mac.yaml
@@ -57,6 +57,39 @@
     RE:
       Disabled: [0, "MAC receive state machine is disabled after the completion of the reception of the current frame"]
       Enabled: [1, "MAC receive state machine is enabled"]
+    _modify:
+      CSTF:
+        description: CRC stripping for type frames
+      WD:
+        description: Watchdog disable
+      JD:
+        description: Jabber disable
+      IFG:
+        description: Interframe gap
+      CSD:
+        description: Carrier sense disable
+      FES:
+        description: Fast Ethernet speed
+      ROD:
+        description: Receive own disable
+      LM:
+        description: Loopback mode
+      DM:
+        description: Duplex mode
+      IPCO:
+        description: IPv4 checksum offload
+      RD:
+        description: Retry disable
+      APCS:
+        description: Automatic pad/CRC stripping
+      BL:
+        description: Back-off limit
+      DC:
+        description: Deferral check
+      TE:
+        description: Transmitter enable
+      RE:
+        description: Receiver enable
 
   MACFFR:
     RA:
@@ -94,12 +127,41 @@
     PM:
       Disabled: [0, "Normal address filtering"]
       Enabled: [1, "Address filters pass all incoming frames regardless of their destination or source address"]
+    _modify:
+      RA:
+        description: Receive all
+      HPF:
+        description: Hash or perfect filter
+      SAF:
+        description: Source address filter
+      SAIF:
+        description: Source address inverse filtering
+      PCF:
+        description: Pass control frames
+      BFD:
+        description: Broadcast frames disable
+      RAM:
+        description: Pass all multicast
+      DAIF:
+        description: Destination address unique filtering
+      HM:
+        description: Hash multicast
+      HU:
+        description: Hash unicast
+      PM:
+        description: Promiscuous mode
 
   MACHTHR:
     HTH: [0, 0xFFFFFFFF]
+    _modify:
+      HTH:
+        description: Upper 32 bits of hash table
 
   MACHTLR:
     HTL: [0, 0xFFFFFFFF]
+    _modify:
+      HTL:
+        description: Lower 32 bits of hash table
 
   MACMIIAR:
     PA: [0, 0x1F]
@@ -115,9 +177,23 @@
       Write: [1, "Write operation"]
     MB:
       Busy: [1, "This bit is set to 1 by the application to indicate that a read or write access is in progress"]
+    _modify:
+      PA:
+        description: PHY address - select which of possible 32 PHYs is being accessed
+      MR:
+        description: MII register - select the desired MII register in the PHY device
+      CR:
+        description: Clock range
+      MW:
+        description: MII write
+      MB:
+        description: MII busy
 
   MACMIIDR:
     MD: [0, 0xFFFF]
+    _modify:
+      MD:
+        description: MII data read from/written to the PHY
 
   MACFCR:
     PT: [0, 0xFFFF]
@@ -141,13 +217,32 @@
     FCB:
       PauseOrBackPressure: [1, "In full duplex, initiate a Pause control frame. In half duplex, assert back pressure"]
       DisableBackPressure: [0, "In half duplex only, deasserts back pressure"]
-
+    _modify:
+      PT:
+        description: Pause time
+      ZQPD:
+        description: Zero-quanta pause disable
+      PLT:
+        description: Pause low threshold
+      UPFD:
+        description: Unicast pause frame detect
+      RFCE:
+        description: Receive flow control enable
+      TFCE:
+        description: Transmit flow control enable
+      FCB:
+        description: Flow control busy/back pressure activate
 
   MACVLANTR:
     VLANTC:
       VLANTC16: [0, "Full 16 bit VLAN identifiers are used for comparison and filtering"]
       VLANTC12: [1, "12 bit VLAN identifies are used for comparison and filtering"]
     VLANTI: [0, 0xFFFF]
+    _modify:
+      VLANTC:
+        description: 12-bit VLAN tag comparison
+      VLANTI:
+        description: VLAN tag identifier (for receive frames)
 
   MACPMTCSR:
     WFFRPR:
@@ -163,6 +258,34 @@
       Enabled: [1, "Enable generation of a power management event due to Magic Packet reception"]
     PD:
       Enabled: [1, "All received frames will be dropped. Cleared automatically when a magic packet or wakeup frame is received"]
+    _modify:
+      WFFRPR:
+        description: Wakeup frame filter register pointer reset
+      GU:
+        description: Global unicast
+      WFR:
+        description: Wakeup frame received
+      MPR:
+        description: Magic packet received
+      WFE:
+        description: Wakeup frame enable
+      MPE:
+        description: Magic packet enable
+      PD:
+        description: Power down
+
+  MACSR:
+    _modify:
+      TSTS:
+        description: Time stamp trigger status
+      MMCTS:
+        description: MMC transmit status
+      MMCRS:
+        description: MMC receive status
+      MMCS:
+        description: MMC status
+      PMTS:
+        description: PMT status
 
   MACIMR:
     TSTIM:
@@ -171,6 +294,11 @@
     PMTIM:
       Unmasked: [0, "PMT Status interrupt generation enabled"]
       Masked: [1, "PMT Status interrupt generation disabled"]
+    _modify:
+      TSTIM:
+        description: Time stamp trigger interrupt mask
+      PMTIM:
+        description: PMT interrupt mask
 
   MACA0HR:
     MACA0H: [0, 0xFFFF]

--- a/peripherals/eth/eth_mmc.yaml
+++ b/peripherals/eth/eth_mmc.yaml
@@ -17,6 +17,37 @@
       Enabled: [1, "Counters do not roll over to zero after reaching the maximum value"]
     CR:
       Reset: [1, "Reset all counters. Cleared automatically"]
+    _modify:
+      MCFHP:
+        description: MMC counter Full-Half preset
+      MCP:
+        description: MMC counter preset
+      MCF:
+        description: MMC counter freeze
+      ROR:
+        description: Reset on read
+      CSR:
+        description: Counter stop rollover
+      CR:
+        description: Counter reset
+
+  MMCRIR:
+    _modify:
+      RGUFS:
+        description: Received good Unicast frames status
+      RFAES:
+        description: Received frames alignment error status
+      RFCES:
+        description: Received frames CRC error status
+
+  MMCTIR:
+    _modify:
+      TGFS:
+        description: Transmitted good frames status
+      TGFMSCS:
+        description: Transmitted good frames more than single collision status
+      TGFSCS:
+        description: Transmitted good frames single collision status
 
   MMCRIMR:
     RGUFM:
@@ -28,6 +59,13 @@
     RFCEM:
       Unmasked: [0, "Received-crc-error counter half-full interrupt enabled"]
       Masked: [1, "Received-crc-error counter half-full interrupt disabled"]
+    _modify:
+      RGUFM:
+        description: Received good Unicast frames mask
+      RFAEM:
+        description: Received frames alignment error mask
+      RFCEM:
+        description: Received frame CRC error mask
 
   MMCTIMR:
     TGFM:
@@ -39,3 +77,15 @@
     TGFSCM:
       Unmasked: [0, "Transmitted-good-single-collision half-full interrupt enabled"]
       Masked: [1, "Transmitted-good-single-collision half-full interrupt disabled"]
+    _modify:
+      TGFM:
+        description: Transmitted good frames mask
+      TGFMSCM:
+        description: Transmitted good frames more than single collision mask
+      TGFSCM:
+        description: Transmitted good frames single collision mask
+
+  MMCTGFSCCR:
+    _modify:
+      TGFSCC:
+        description: Transmitted good frames single collision counter


### PR DESCRIPTION
This is purely docstrings. There are, however, two things I have noticed that require renamings (using the STM32F429 ref. manual as the authority):

* `RAM` in `MACFFR` should be `PAM` (Pass all multicast)
* The fields in `MACDBGR` are completely wrong - they seem to be copied from `ETH_MMCCR`.

What is the approach to such changes?