### PR TITLE
Change `package.metadata.docs.rs` for stm32l4

### DIFF
--- a/stm32l4/Cargo.toml
+++ b/stm32l4/Cargo.toml
@@ -19,7 +19,7 @@ optional = true
 version = "0.6.4"
 
 [package.metadata.docs.rs]
-features = ['rt', 'stm32l4x1', 'stm32l4x5']
+features = ['rt', 'stm32l4x2', 'stm32l4x6']
 
 [features]
 default = []


### PR DESCRIPTION
Generally, would make sense to align documented devices with availability of Nucleo boards.