### PR TITLE
attempt to fix USB peripheral for stm32l4x2

### DIFF
--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -12,6 +12,27 @@ RCC:
         name: USBFSEN
         description: USB FS clock enable
 
+# cf. <https://github.com/adamgreig/stm32-rs/issues/37>
+# we call the resulting peripheral `USB` instead of `USB-FS`
+# to be aligned with `mvirkkunen/stm32f103-usb`
+
+_modify:
+  USB_SRAM:
+     name: USB
+     # without quotes, get less readable value 1073768448
+     baseAddress: "0x40006800"
+
+USB:
+  _add:
+    _interrupts:
+      # the interrupt is listed under USB_FS, which we delete
+      USB:
+        description: USB event interrupt through EXTI
+        value: 67
+
+_delete:
+  - USB_FS
+
 # Merge the thousands of individal bit fields into a single field for each
 # CAN filter register. This is not only much easier to use but also saves
 # a huge amount of filespace and compilation time etc -- as much as 30% of all


### PR DESCRIPTION
I hope this is correct!

- strangely, stm32l4x3 is not affected by https://github.com/adamgreig/stm32-rs/issues/37
- I renamed the entire peripheral to just `USB` as this is what both l4x3 and f103 do (considering the latter because I will port `mvirkkunen/stm32f103xx-usb`)
- the interrupt was listed under `USB_FS`, it is missing from both l4x3 and f103...
- I don't know if the previous baseAddress `0x4000_6C00` is needed anywhere?
- regarding the `USB_{ADDR,COUNT}n_{TX,RX}` registers, both l4x3 and f103 don't seem to have them; the `usb-device` implementation seems to hardcode it (https://github.com/mvirkkunen/stm32f103xx-usb/blob/master/src/endpoint.rs#L49) - I may send a separate PR if it makes sense to patch them in
