### PR TITLE
TIM: propagate tim_basic to all devices and fix naming of IC1PSC and IC2PSC

### DIFF
--- a/devices/stm32f100.yaml
+++ b/devices/stm32f100.yaml
@@ -15,6 +15,7 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_f1.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml

--- a/devices/stm32f101.yaml
+++ b/devices/stm32f101.yaml
@@ -36,6 +36,7 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_f1.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/dma/dma_v1.yaml

--- a/devices/stm32f102.yaml
+++ b/devices/stm32f102.yaml
@@ -27,6 +27,7 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_f1.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/dma/dma_v1.yaml

--- a/devices/stm32f103.yaml
+++ b/devices/stm32f103.yaml
@@ -35,6 +35,7 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_f1.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/dma/dma_v1.yaml

--- a/devices/stm32f107.yaml
+++ b/devices/stm32f107.yaml
@@ -36,6 +36,7 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_f1.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/dma/dma_v1.yaml

--- a/devices/stm32f215.yaml
+++ b/devices/stm32f215.yaml
@@ -31,6 +31,7 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f217.yaml
+++ b/devices/stm32f217.yaml
@@ -31,6 +31,7 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -32,6 +32,7 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/gpio/gpio_v2.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -20,6 +20,7 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -20,6 +20,7 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -9,6 +9,7 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -11,6 +11,7 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -10,6 +10,7 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -26,6 +26,7 @@ _include:
  - ../peripherals/pwr/pwr_f7.yaml
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -36,6 +36,7 @@ _include:
  - ../peripherals/pwr/pwr_f7.yaml
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f7x5.yaml
+++ b/devices/stm32f7x5.yaml
@@ -152,6 +152,7 @@ _include:
  - ../peripherals/pwr/pwr_f7.yaml
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -135,6 +135,7 @@ _include:
  - ../peripherals/pwr/pwr_f7.yaml
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -300,6 +300,7 @@ _include:
  - ../peripherals/pwr/pwr_f7.yaml
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -287,6 +287,7 @@ _include:
  - ../peripherals/pwr/pwr_f7.yaml
  - ../peripherals/pwr/pwr_v2.yaml
  - ../peripherals/flash/flash_v2.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -318,6 +318,7 @@ _include:
  - common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/gpio/gpio_v2.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -14,6 +14,7 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1_with_remapping.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -20,6 +20,7 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1_with_remapping.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -20,6 +20,7 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/dma/dma_v1_with_remapping.yaml

--- a/devices/stm32l100.yaml
+++ b/devices/stm32l100.yaml
@@ -84,6 +84,7 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_v2.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32l151.yaml
+++ b/devices/stm32l151.yaml
@@ -22,6 +22,7 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../devices/common_patches/gpio_with_OSPEEDER.yaml
  - ../peripherals/gpio/gpio_v2.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32l162.yaml
+++ b/devices/stm32l162.yaml
@@ -22,6 +22,7 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../devices/common_patches/gpio_with_OSPEEDER.yaml
  - ../peripherals/gpio/gpio_v2.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -35,6 +35,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -39,6 +39,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -35,6 +35,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -27,6 +27,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -28,6 +28,7 @@ _include:
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml

--- a/peripherals/tim/tim_basic.yaml
+++ b/peripherals/tim/tim_basic.yaml
@@ -3,6 +3,9 @@
 
 "TIM*":
   CR1:
+    _modify:
+      OMP:
+        name: OPM
     ARPE:
       Disabled: [0, "TIMx_APRR register is not buffered"]
       Enabled: [1, "TIMx_APRR register is buffered"]

--- a/peripherals/tim/tim_basic.yaml
+++ b/peripherals/tim/tim_basic.yaml
@@ -39,3 +39,13 @@
     OPM:
       Disabled: [0, "Counter is not stopped at update event"]
       Enabled: [1, "Counter stops counting at the next update event (clearing the CEN bit)"]
+
+"TIM[1-58-9],TIM1?":
+  CCMR1_Input:
+    _modify:
+      ICPCS:
+        name: IC1PSC
+      IC1PCS:
+        name: IC1PSC
+      IC2PCS:
+        name: IC2PSC


### PR DESCRIPTION
This fixes issue #39