### PR TITLE
Allow rebasing peripherals

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,13 @@ _add:
                 description: ADC global interrupt
                 value: 18
 
+# Reorder the heirarchy of peripherals with 'deriveFrom'.
+_rebase:
+    # The KEY peripheral steals everything but 'interrupt', 'name',
+    # and 'baseAddress' elements from the VALUE peripheral.
+    # Peripherals that were 'deriveFrom="VALUE"' are now 'deriveFrom="KEY"'.
+    I2C1: I2C3
+
 # An STM32 peripheral, matches an SVD <peripheral> tag.
 # Does not match any tag with derivedFrom attribute set.
 "GPIO*":

--- a/devices/stm32f401.yaml
+++ b/devices/stm32f401.yaml
@@ -1,5 +1,9 @@
 _svd: ../svd/stm32f401.svd
 
+_rebase:
+  # Make I2C1 the base type
+  I2C1: I2C3
+
 "I2S*":
   SR:
     _modify:

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -1,5 +1,9 @@
 _svd: ../svd/stm32f405.svd
 
+_rebase:
+  # Make I2C1 the base type
+  I2C1: I2C3
+
 _modify:
   # The SVD calls this C_ADC in some devices and ADC_Common in others,
   # we'll prefer the more sensible (and better for sorting) ADC_Common

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -1,5 +1,9 @@
 _svd: ../svd/stm32f407.svd
 
+_rebase:
+  # Make I2C1 the base type
+  I2C1: I2C3
+
 _modify:
   # The SVD calls this C_ADC in some devices and ADC_Common in others,
   # we'll prefer the more sensible (and better for sorting) ADC_Common

--- a/devices/stm32f410.yaml
+++ b/devices/stm32f410.yaml
@@ -1,5 +1,9 @@
 _svd: ../svd/stm32f410.svd
 
+_rebase:
+  # Make I2C1 the base type
+  I2C1: I2C2
+
 "SPI*":
   SR:
     _modify:

--- a/devices/stm32f411.yaml
+++ b/devices/stm32f411.yaml
@@ -1,5 +1,9 @@
 _svd: ../svd/stm32f411.svd
 
+_rebase:
+  # Make I2C1 the base type
+  I2C1: I2C3
+
 "I2S*":
   SR:
     _modify:

--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -1,5 +1,9 @@
 _svd: ../svd/stm32f412.svd
 
+_rebase:
+  # Make I2C1 the base type
+  I2C1: I2C3
+
 "I2S*":
   SR:
     _modify:

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -1,5 +1,9 @@
 _svd: ../svd/stm32f413.svd
 
+_rebase:
+  # Make I2C1 the base type
+  I2C1: I2C2
+
 "SPI*":
   SR:
     _modify:

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -1,5 +1,9 @@
 _svd: ../svd/stm32f427.svd
 
+_rebase:
+  # Make I2C1 the base type
+  I2C1: I2C3
+
 _modify:
   # The SVD calls this C_ADC in some devices and ADC_Common in others,
   # we'll prefer the more sensible (and better for sorting) ADC_Common

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -1,5 +1,9 @@
 _svd: ../svd/stm32f429.svd
 
+_rebase:
+  # Make I2C1 the base type
+  I2C1: I2C3
+
 _modify:
   # The SVD calls this C_ADC in some devices and ADC_Common in others,
   # we'll prefer the more sensible (and better for sorting) ADC_Common

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -1,5 +1,9 @@
 _svd: ../svd/stm32f446.svd
 
+_rebase:
+  # Make I2C1 the base type
+  I2C1: I2C3
+
 _modify:
   # The SVD calls this C_ADC in some devices and ADC_Common in others,
   # we'll prefer the more sensible (and better for sorting) ADC_Common

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -1,5 +1,9 @@
 _svd: ../svd/stm32f469.svd
 
+_rebase:
+  # Make I2C1 the base type
+  I2C1: I2C3
+
 _modify:
   # The SVD calls this C_ADC in some devices and ADC_Common in others,
   # we'll prefer the more sensible (and better for sorting) ADC_Common

--- a/scripts/svdpatch.py
+++ b/scripts/svdpatch.py
@@ -240,6 +240,26 @@ def process_device_add(device, pname, padd):
     pnew.tail = "\n    "
 
 
+def process_device_rebase(device, pnew, pold):
+    """Move registers from pold to pnew. Update all derivedFrom referencing pold"""
+    parent = device.find('peripherals')
+    old = parent.find('./peripheral[name=\'{}\']'.format(pold))
+    new = parent.find('./peripheral[name=\'{}\']'.format(pnew))
+    if old is None:
+        raise SvdPatchError('peripheral {} not found'.format(pold))
+    if new is None:
+        raise SvdPatchError('peripheral {} not found'.format(pnew))
+    for (value) in list(old):
+        if value.tag == 'name' or value.tag == 'baseAddress' or value.tag == 'interrupt':
+            continue
+        old.remove(value)
+        new.append(value)
+    del new.attrib['derivedFrom']
+    old.set('derivedFrom', pnew)
+    for p in parent.findall('./peripheral[@derivedFrom=\'{}\']'.format(pold)):
+        p.set('derivedFrom', pnew)
+
+
 def process_peripheral_add_reg(ptag, rname, radd):
     """Add rname given by radd to ptag."""
     parent = ptag.find('registers')
@@ -513,6 +533,11 @@ def process_device(svd, device, update_fields=True):
     for pname in device.get("_add", []):
         padd = device["_add"][pname]
         process_device_add(svd, pname, padd)
+
+    # Handle any rebased peripherals
+    for pname in device.get("_rebase", []):
+        pold = device["_rebase"][pname]
+        process_device_rebase(svd, pname, pold)
 
     # Now process all peripherals
     for periphspec in device:

--- a/scripts/svdpatch.py
+++ b/scripts/svdpatch.py
@@ -249,11 +249,17 @@ def process_device_rebase(device, pnew, pold):
         raise SvdPatchError('peripheral {} not found'.format(pold))
     if new is None:
         raise SvdPatchError('peripheral {} not found'.format(pnew))
+    for value in new:
+        last = value
+    last.tail = "\n      "
     for (value) in list(old):
         if value.tag == 'name' or value.tag == 'baseAddress' or value.tag == 'interrupt':
             continue
         old.remove(value)
         new.append(value)
+    for value in old:
+        last = value
+    last.tail = "\n    "
     del new.attrib['derivedFrom']
     old.set('derivedFrom', pnew)
     for p in parent.findall('./peripheral[@derivedFrom=\'{}\']'.format(pold)):


### PR DESCRIPTION
This is the implementation of my idea in #97.

Specify in a device yaml as follows (I'm sure this can be improved, just not sure how):
```yaml
_rebase:
  I2C1: I2C3
```

It was a coin toss as to when the rebase occurs, before or after modifying peripherals.