### PR TITLE
Reset and clock control for AHB/APB peripherals on stm32f0

### DIFF
--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -1,6 +1,22 @@
 _svd: ../svd/stm32f0x0.svd
 
 RCC:
+  APB2RSTR:
+    _add:
+      USART6RST:
+        description: "USART6 reset"
+        bitOffset: 5
+        bitWidth: 1
+  AHBENR:
+    _add:
+      IOPDEN:
+        description: "I/O port D clock enable"
+        bitOffset: 20
+        bitWidth: 1
+      DMAEN:
+        description: "DMA clock enable"
+        bitOffset: 0
+        bitWidth: 1
   APB2ENR:
     _add:
       USART6EN:

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -1,5 +1,13 @@
 _svd: ../svd/stm32f0x0.svd
 
+RCC:
+  APB2ENR:
+    _add:
+      USART6EN:
+        description: "USART6 clock enable"
+        bitOffset: 5
+        bitWidth: 1
+
 _include:
  - ./common_patches/rename_RCC_CIR_HSI14RDYIE_field.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -7,6 +7,14 @@ Flash:
       RAM_PARITY_CHECK:
         bitWidth: 1
 
+RCC:
+  AHBENR:
+    _add:
+      DMAEN:
+        description: "DMA clock enable"
+        bitOffset: 0
+        bitWidth: 1
+
 _include:
  - ./common_patches/rename_RCC_CIR_HSI14RDYIE_field.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -1,11 +1,35 @@
 _svd: ../svd/stm32f0x2.svd
 
 RCC:
+  APB2RSTR:
+    _add:
+      USART6RST:
+        description: "USART6 reset"
+        bitOffset: 5
+        bitWidth: 1
+  APB1RSTR:
+    _add:
+      USART5RST:
+        description: "USART5 reset"
+        bitOffset: 20
+        bitWidth: 1
+  AHBENR:
+    _add:
+      DMAEN:
+        description: "DMA clock enable"
+        bitOffset: 0
+        bitWidth: 1
   APB2ENR:
     _add:
       USART6EN:
         description: "USART6 clock enable"
         bitOffset: 5
+        bitWidth: 1
+  APB1ENR:
+    _add:
+      USART5EN:
+        description: "USART5 clock enable"
+        bitOffset: 20
         bitWidth: 1
 
 _include:

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -1,5 +1,13 @@
 _svd: ../svd/stm32f0x2.svd
 
+RCC:
+  APB2ENR:
+    _add:
+      USART6EN:
+        description: "USART6 clock enable"
+        bitOffset: 5
+        bitWidth: 1
+
 _include:
  - ./common_patches/rename_RCC_CIR_HSI14RDYIE_field.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -1,5 +1,13 @@
 _svd: ../svd/stm32f0x8.svd
 
+RCC:
+  APB2ENR:
+    _add:
+      USART6EN:
+        description: "USART6 clock enable"
+        bitOffset: 5
+        bitWidth: 1
+
 _include:
  - ./common_patches/rename_RCC_CIR_HSI14RDYIE_field.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -1,6 +1,18 @@
 _svd: ../svd/stm32f0x8.svd
 
 RCC:
+  APB2RSTR:
+    _add:
+      USART6RST:
+        description: "USART6 reset"
+        bitOffset: 5
+        bitWidth: 1
+  AHBENR:
+    _add:
+      DMAEN:
+        description: "DMA clock enable"
+        bitOffset: 0
+        bitWidth: 1
   APB2ENR:
     _add:
       USART6EN:

--- a/peripherals/rcc/rcc_f0.yaml
+++ b/peripherals/rcc/rcc_f0.yaml
@@ -189,3 +189,68 @@ RCC:
       _read:
         NotInterrupted: [0, "No clock ready interrupt caused by the LSI oscillator"]
         Interrupted: [1, "Clock ready interrupt caused by the LSI oscillator"]
+  APB2ENR:
+    DBGMCUEN:
+      Disabled: [0, "MCU debug module clock disabled"]
+      Enabled: [1, "MCU debug module enabled"]
+    TIM17EN:
+      Disabled: [0, "TIM17 timer clock disabled"]
+      Enabled: [1, "TIM17 timer clock enabled"]
+    TIM16EN:
+      Disabled: [0, "TIM16 timer clock disabled"]
+      Enabled: [1, "TIM16 timer clock enabled"]
+    TIM15EN:
+      Disabled: [0, "TIM15 timer clock disabled"]
+      Enabled: [1, "TIM15 timer clock enabled"]
+    USART1EN:
+      Disabled: [0, "USART1 clock disabled"]
+      Enabled: [1, "USART1 clock enabled"]
+    SPI1EN:
+      Disabled: [0, "SPI1 clock disabled"]
+      Enabled: [1, "SPI1 clock enabled"]
+    TIM1EN:
+      Disabled: [0, "TIM1 timer clock disabled"]
+      Enabled: [1, "TIM1 timer clock enabled"]
+    ADCEN:
+      Disabled: [0, "ADC interface disabled"]
+      Enabled: [1, "ADC interface enabled"]
+    SYSCFGEN:
+      Disabled: [0, "SYSCFG clock disabled"]
+      Enabled: [1, "SYSCFG clock enabled"]
+  APB1ENR:
+    PWREN:
+      Disabled: [0, "Power interface clock disabled"]
+      Enabled: [1, "Power interface clock enabled"]
+    I2C2EN:
+      Disabled: [0, "I2C2 clock disabled"]
+      Enabled: [1, "I2C2 clock enabled"]
+    I2C1EN:
+      Disabled: [0, "I2C1 clock disabled"]
+      Enabled: [1, "I2C1 clock enabled"]
+    USART4EN:
+      Disabled: [0, "USART4 clock disabled"]
+      Enabled: [1, "USART4 clock enabled"]
+    USART3EN:
+      Disabled: [0, "USART3 clock disabled"]
+      Enabled: [1, "USART3 clock enabled"]
+    USART2EN:
+      Disabled: [0, "USART2 clock disabled"]
+      Enabled: [1, "USART2 clock enabled"]
+    SPI2EN:
+      Disabled: [0, "SPI2 clock disabled"]
+      Enabled: [1, "SPI2 clock enabled"]
+    WWDGEN:
+      Disabled: [0, "Window watchdog clock disabled"]
+      Enabled: [1, "Window watchdog clock enabled"]
+    TIM14EN:
+      Disabled: [0, "TIM14EN clock disabled"]
+      Enabled: [1, "TIM14EN clock enabled"]
+    TIM7EN:
+      Disabled: [0, "TIM7EN clock disabled"]
+      Enabled: [1, "TIM7EN clock enabled"]
+    TIM6EN:
+      Disabled: [0, "TIM6EN clock disabled"]
+      Enabled: [1, "TIM6EN clock enabled"]
+    TIM3EN:
+      Disabled: [0, "TIM3EN clock disabled"]
+      Enabled: [1, "TIM3EN clock enabled"]

--- a/peripherals/rcc/rcc_f0.yaml
+++ b/peripherals/rcc/rcc_f0.yaml
@@ -189,6 +189,82 @@ RCC:
       _read:
         NotInterrupted: [0, "No clock ready interrupt caused by the LSI oscillator"]
         Interrupted: [1, "Clock ready interrupt caused by the LSI oscillator"]
+  APB2RSTR:
+    DBGMCURST:
+      Reset: [1, "Reset Debug MCU"]
+    TIM17RST:
+      Reset: [1, "Reset TIM17 timer"]
+    TIM16RST:
+      Reset: [1, "Reset TIM16 timer"]
+    TIM15RST:
+      Reset: [1, "Reset TIM15 timer"]
+    USART1RST:
+      Reset: [1, "Reset USART1"]
+    SPI1RST:
+      Reset: [1, "Reset SPI1"]
+    TIM1RST:
+      Reset: [1, "Reset TIM1 timer"]
+    ADCRST:
+      Reset: [1, "Reset ADC interface"]
+    SYSCFGRST:
+      Reset: [1, "Reset SYSCFG"]
+  APB1RSTR:
+    PWRRST:
+      Reset: [1, "Reset power interface"]
+    USBRST:
+      Reset: [1, "Reset USB interface"]
+    I2C2RST:
+      Reset: [1, "Reset I2C2"]
+    I2C1RST:
+      Reset: [1, "Reset I2C1"]
+    USART5RST:
+      Reset: [1, "Reset USART5"]
+    USART4RST:
+      Reset: [1, "Reset USART4"]
+    USART3RST:
+      Reset: [1, "Reset USART3"]
+    USART2RST:
+      Reset: [1, "Reset USART2"]
+    SPI2RST:
+      Reset: [1, "Reset SPI2"]
+    WWDGRST:
+      Reset: [1, "Reset window watchdog"]
+    TIM14RST:
+      Reset: [1, "Reset TIM14"]
+    TIM7RST:
+      Reset: [1, "Reset TIM7"]
+    TIM6RST:
+      Reset: [1, "Reset TIM6"]
+    TIM3RST:
+      Reset: [1, "Reset TIM3"]
+  AHBENR:
+    IOPFEN:
+      Disabled: [0, "I/O port F clock disabled"]
+      Enabled: [1, "I/O port F clock enabled"]
+    IOPDEN:
+      Disabled: [0, "I/O port D clock disabled"]
+      Enabled: [1, "I/O port D clock enabled"]
+    IOPCEN:
+      Disabled: [0, "I/O port C clock disabled"]
+      Enabled: [1, "I/O port C clock enabled"]
+    IOPBEN:
+      Disabled: [0, "I/O port B clock disabled"]
+      Enabled: [1, "I/O port B clock enabled"]
+    IOPAEN:
+      Disabled: [0, "I/O port A clock disabled"]
+      Enabled: [1, "I/O port A clock enabled"]
+    CRCEN:
+      Disabled: [0, "CRC clock disabled"]
+      Enabled: [1, "CRC clock enabled"]
+    FLITFEN:
+      Disabled: [0, "FLITF clock disabled during Sleep mode"]
+      Enabled: [1, "FLITF clock enabled during Sleep mode"]
+    SRAMEN:
+      Disabled: [0, "SRAM interface clock disabled during Sleep mode"]
+      Enabled: [1, "SRAM interface clock enabled during Sleep mode"]
+    DMAEN:
+      Disabled: [0, "DMA clock disabled"]
+      Enabled: [1, "DMA clock enabled"]
   APB2ENR:
     DBGMCUEN:
       Disabled: [0, "MCU debug module clock disabled"]
@@ -214,6 +290,9 @@ RCC:
     ADCEN:
       Disabled: [0, "ADC interface disabled"]
       Enabled: [1, "ADC interface enabled"]
+    USART6EN:
+      Disabled: [0, "USART6 clock disabled"]
+      Enabled: [1, "USART6 clock enabled"]
     SYSCFGEN:
       Disabled: [0, "SYSCFG clock disabled"]
       Enabled: [1, "SYSCFG clock enabled"]
@@ -230,6 +309,9 @@ RCC:
     I2C1EN:
       Disabled: [0, "I2C1 clock disabled"]
       Enabled: [1, "I2C1 clock enabled"]
+    USART5EN:
+      Disabled: [0, "USART5 clock disabled"]
+      Enabled: [1, "USART5 clock enabled"]
     USART4EN:
       Disabled: [0, "USART4 clock disabled"]
       Enabled: [1, "USART4 clock enabled"]
@@ -257,3 +339,14 @@ RCC:
     TIM3EN:
       Disabled: [0, "TIM3EN clock disabled"]
       Enabled: [1, "TIM3EN clock enabled"]
+  AHBRSTR:
+    IOPFRST:
+      Reset: [1, "Reset I/O port F"]
+    IOPDRST:
+      Reset: [1, "Reset I/O port D"]
+    IOPCRST:
+      Reset: [1, "Reset I/O port C"]
+    IOPBRST:
+      Reset: [1, "Reset I/O port B"]
+    IOPARST:
+      Reset: [1, "Reset I/O port A"]

--- a/peripherals/rcc/rcc_f0.yaml
+++ b/peripherals/rcc/rcc_f0.yaml
@@ -218,6 +218,9 @@ RCC:
       Disabled: [0, "SYSCFG clock disabled"]
       Enabled: [1, "SYSCFG clock enabled"]
   APB1ENR:
+    _modify:
+      USBRST:
+        name: "USBEN"
     PWREN:
       Disabled: [0, "Power interface clock disabled"]
       Enabled: [1, "Power interface clock enabled"]


### PR DESCRIPTION
If I understand things correctly (which I'm not exactly confident about :wink:), this should add support for the `APB2ENR` and `APB1ENR` registers for the STM32F0 series of devices.

This information was pulled from the reference for the [STM32F0X0 devices](https://www.st.com/content/ccc/resource/technical/document/reference_manual/cf/10/a8/c4/29/fb/4c/42/DM00091010.pdf/files/DM00091010.pdf/jcr:content/translations/en.DM00091010.pdf) specifically.

`APB2ENR` is missing `USART6EN`, and `APB1ENR` is missing `USBEN`, as they threw errors during compilation and frankly I don't understand the project well enough how to fix it yet.

Let me know if this is correct and/or if any changes need to be made. If I messed it up I can always give it another go. Thanks for all the hard work that has gone into this project!